### PR TITLE
goctl生成Kotlin代码优化

### DIFF
--- a/tools/goctl/api/gogen/genroutes.go
+++ b/tools/goctl/api/gogen/genroutes.go
@@ -43,6 +43,7 @@ var mapping = map[string]string{
 	"head":   "http.MethodHead",
 	"post":   "http.MethodPost",
 	"put":    "http.MethodPut",
+	"patch":  "http.MethodPatch",
 }
 
 type (

--- a/tools/goctl/api/ktgen/funcs.go
+++ b/tools/goctl/api/ktgen/funcs.go
@@ -1,6 +1,7 @@
 package ktgen
 
 import (
+	"github.com/iancoleman/strcase"
 	"log"
 	"strings"
 	"text/template"
@@ -9,11 +10,11 @@ import (
 )
 
 var funcsMap = template.FuncMap{
-	"lowCamelCase":   lowCamelCase,
-	"pathToFuncName": pathToFuncName,
-	"parseType":      parseType,
-	"add":            add,
-	"upperCase":      upperCase,
+	"lowCamelCase":    lowCamelCase,
+	"routeToFuncName": routeToFuncName,
+	"parseType":       parseType,
+	"add":             add,
+	"upperCase":       upperCase,
 }
 
 func lowCamelCase(s string) string {
@@ -24,16 +25,16 @@ func lowCamelCase(s string) string {
 	return util.ToLower(s[:1]) + s[1:]
 }
 
-func pathToFuncName(path string) string {
+func routeToFuncName(method, path string) string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
 
 	path = strings.ReplaceAll(path, "/", "_")
 	path = strings.ReplaceAll(path, "-", "_")
+	path = strings.ReplaceAll(path, ":", "With_")
 
-	camel := util.ToCamelCase(path)
-	return util.ToLower(camel[:1]) + camel[1:]
+	return strings.ToLower(method)+strcase.ToCamel(path)
 }
 
 func parseType(t string) string {

--- a/tools/goctl/api/ktgen/funcs.go
+++ b/tools/goctl/api/ktgen/funcs.go
@@ -1,11 +1,11 @@
 package ktgen
 
 import (
-	"github.com/iancoleman/strcase"
 	"log"
 	"strings"
 	"text/template"
 
+	"github.com/iancoleman/strcase"
 	"github.com/tal-tech/go-zero/tools/goctl/api/util"
 )
 

--- a/tools/goctl/api/ktgen/gen.go
+++ b/tools/goctl/api/ktgen/gen.go
@@ -83,7 +83,7 @@ object {{with .Info}}{{.Title}}{{end}}{
 		val {{with $item}}{{lowCamelCase .Name}}: {{parseType .Type}}{{end}}{{if ne $i (add $length -1)}},{{end}}{{end}}
 	){{end}}
 	{{with .Service}}
-	{{range .Routes}}suspend fun {{pathToFuncName .Path}}({{with .RequestType}}{{if ne .Name ""}}
+	{{range .Routes}}suspend fun {{routeToFuncName .Method .Path}}({{with .RequestType}}{{if ne .Name ""}}
 		req:{{.Name}},{{end}}{{end}}
 		onOk: (({{with .ResponseType}}{{.Name}}{{end}}) -> Unit)? = null,
         onFail: ((String) -> Unit)? = null,

--- a/tools/goctl/api/ktgen/gen.go
+++ b/tools/goctl/api/ktgen/gen.go
@@ -37,7 +37,7 @@ suspend fun apiRequest(
         connectTimeout = 3000
         requestMethod = method
         doInput = true
-        if (method == "POST" || method == "PUT") {
+        if (method == "POST" || method == "PUT" || method == "PATCH") {
             setRequestProperty("Content-Type", "application/json")
             doOutput = true
             val data = when (body) {


### PR DESCRIPTION
修复问题：

- 1.Kotlin HttpUrlConnection在连接失败或者超时之后抛出的Exception没有catch
- 2.生成的API命名问题：函数名前加入了Method名，防止有些接口URI相同但是方法不同，导致生成的Kotlin函数重复
- 3.修复了`/users/:id`这样的路径参数导致生成的Kotlin函数名带有冒号的问题
- 4.添加了连接超时3秒
- 5.goctl添加了HTTP PATCH方法支持

关于接口函数命名，应该以方法名+路由URI作为这个接口的唯一表示，这样才能保证生成的函数名不会重复。

比如这几个Restful API

- get /users
- get /users/:id
- post /users
- put /users
- delete /users/:id

生成的客户端接口函数名分别是

- getUsers()
- getUsersWithId()
- postUsers()
- putUsers()
- deleteUsersWithId()
