### PR TITLE
goctl添加jwt annotation支持

### DIFF
--- a/tools/goctl/api/gogen/gen.go
+++ b/tools/goctl/api/gogen/gen.go
@@ -47,7 +47,7 @@ func GoCommand(c *cli.Context) error {
 
 	logx.Must(util.MkdirIfNotExist(dir))
 	logx.Must(genEtc(dir, api))
-	logx.Must(genConfig(dir))
+	logx.Must(genConfig(dir,api))
 	logx.Must(genMain(dir, api))
 	logx.Must(genServiceContext(dir, api))
 	logx.Must(genTypes(dir, api))

--- a/tools/goctl/api/gogen/gen.go
+++ b/tools/goctl/api/gogen/gen.go
@@ -47,7 +47,7 @@ func GoCommand(c *cli.Context) error {
 
 	logx.Must(util.MkdirIfNotExist(dir))
 	logx.Must(genEtc(dir, api))
-	logx.Must(genConfig(dir,api))
+	logx.Must(genConfig(dir, api))
 	logx.Must(genMain(dir, api))
 	logx.Must(genServiceContext(dir, api))
 	logx.Must(genTypes(dir, api))

--- a/tools/goctl/api/gogen/genconfig.go
+++ b/tools/goctl/api/gogen/genconfig.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/tal-tech/go-zero/tools/goctl/api/spec"
 	"github.com/tal-tech/go-zero/tools/goctl/api/util"
 	"github.com/tal-tech/go-zero/tools/goctl/vars"
 )
@@ -23,7 +24,7 @@ type Config struct {
 `
 )
 
-func genConfig(dir string) error {
+func genConfig(dir string, api *spec.ApiSpec) error {
 	fp, created, err := util.MaybeCreateFile(dir, configDir, configFile)
 	if err != nil {
 		return err

--- a/tools/goctl/api/gogen/genroutes.go
+++ b/tools/goctl/api/gogen/genroutes.go
@@ -177,6 +177,11 @@ func getRoutes(api *spec.ApiSpec) ([]group, error) {
 				handler: handler,
 			})
 		}
+
+		if authName, ok := apiutil.GetAnnotationValue(g.Annotations, "server", "jwt"); ok {
+			groupedRoutes.jwtEnabled = true
+			groupedRoutes.authName = authName
+		}
 		routes = append(routes, groupedRoutes)
 	}
 

--- a/tools/goctl/api/gogen/genroutes.go
+++ b/tools/goctl/api/gogen/genroutes.go
@@ -81,7 +81,7 @@ func genRoutes(dir string, api *spec.ApiSpec) error {
 		}
 		var jwt string
 		if g.jwtEnabled {
-			jwt = fmt.Sprintf(", ngin.WithJwt(serverCtx.Config.%s.AccessSecret)", g.authName)
+			jwt = fmt.Sprintf(", rest.WithJwt(serverCtx.Config.%s.AccessSecret)", g.authName)
 		}
 		var signature string
 		if g.signatureEnabled {


### PR DESCRIPTION
对于包含jwt annotation的路由组
```go
@server(
    jwt: Auth
)
service user-api {
    ....
```
现在可以在`handler/routes.go`里面自动给路由组添加jwt代码了

```go
	engine.AddRoutes([]rest.Route{
                 ...
	}, rest.WithJwt(serverCtx.Config.Auth.AccessSecret))
```

# 另外

我还改了一下genconfig.go，给genConfig函数添加了第二个api参数，因为以后肯定要根据是否开启jwt，来决定config.go文件里面要不要加jwt配置。