### PR TITLE
fix command run result is /dev/null

### DIFF
--- a/tools/goctl/rpc/execx/execx.go
+++ b/tools/goctl/rpc/execx/execx.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 func Run(arg string) (string, error) {
@@ -32,5 +34,9 @@ func Run(arg string) (string, error) {
 		return "", err
 	}
 
-	return dtsout.String(), nil
+	dtsOutRes := strings.TrimSpace(dtsout.String())
+	if dtsOutRes == os.DevNull {
+		dtsOutRes = ""
+	}
+	return dtsOutRes, nil
 }


### PR DESCRIPTION
goctl生成rpc代码问题：
1. 运行`go env GOMOD`命令时，如果当前项目下没有go.mod文件时，返回`/dev/null`结果
2. 返回`/dev/null`结果后引起`goctl/rpc/ctx/project.go`文件中`if len(goMod) > 0 `71行永远大于0，无法进入else