### PR TITLE
修复model自动生成中findOneByField()方法

### DIFF
--- a/tools/goctl/model/sql/gen/delete.go
+++ b/tools/goctl/model/sql/gen/delete.go
@@ -22,7 +22,7 @@ func genDelete(table Table, withCache bool) (string, error) {
 	}
 	var containsIndexCache = false
 	for _, item := range table.Fields {
-		if item.IsKey && !item.IsPrimaryKey {
+		if item.IsUniqueKey {
 			containsIndexCache = true
 			break
 		}

--- a/tools/goctl/model/sql/gen/fineonebyfield.go
+++ b/tools/goctl/model/sql/gen/fineonebyfield.go
@@ -14,7 +14,7 @@ func genFineOneByField(table Table, withCache bool) (string, error) {
 	var list []string
 	camelTableName := table.Name.ToCamel()
 	for _, field := range table.Fields {
-		if field.IsPrimaryKey || !field.IsKey {
+		if field.IsPrimaryKey || !field.IsUniqueKey {
 			continue
 		}
 		camelFieldName := field.Name.ToCamel()

--- a/tools/goctl/model/sql/gen/keys.go
+++ b/tools/goctl/model/sql/gen/keys.go
@@ -29,22 +29,21 @@ func genCacheKeys(table parser.Table) (map[string]Key, error) {
 	camelTableName := table.Name.ToCamel()
 	lowerStartCamelTableName := stringx.From(camelTableName).UnTitle()
 	for _, field := range fields {
-		if !field.IsKey {
-			continue
-		}
-		camelFieldName := field.Name.ToCamel()
-		lowerStartCamelFieldName := stringx.From(camelFieldName).UnTitle()
-		left := fmt.Sprintf("cache%s%sPrefix", camelTableName, camelFieldName)
-		right := fmt.Sprintf("cache#%s#%s#", camelTableName, lowerStartCamelFieldName)
-		variable := fmt.Sprintf("%s%sKey", lowerStartCamelTableName, camelFieldName)
-		m[field.Name.Source()] = Key{
-			VarExpression:     fmt.Sprintf(`%s = "%s"`, left, right),
-			Left:              left,
-			Right:             right,
-			Variable:          variable,
-			KeyExpression:     fmt.Sprintf(`%s := fmt.Sprintf("%s%s", %s,%s)`, variable, "%s", "%v", left, lowerStartCamelFieldName),
-			DataKeyExpression: fmt.Sprintf(`%s := fmt.Sprintf("%s%s",%s, data.%s)`, variable, "%s", "%v", left, camelFieldName),
-			RespKeyExpression: fmt.Sprintf(`%s := fmt.Sprintf("%s%s", %s,resp.%s)`, variable, "%s", "%v", left, camelFieldName),
+		if field.IsUniqueKey || field.IsPrimaryKey {
+			camelFieldName := field.Name.ToCamel()
+			lowerStartCamelFieldName := stringx.From(camelFieldName).UnTitle()
+			left := fmt.Sprintf("cache%s%sPrefix", camelTableName, camelFieldName)
+			right := fmt.Sprintf("cache#%s#%s#", camelTableName, lowerStartCamelFieldName)
+			variable := fmt.Sprintf("%s%sKey", lowerStartCamelTableName, camelFieldName)
+			m[field.Name.Source()] = Key{
+				VarExpression:     fmt.Sprintf(`%s = "%s"`, left, right),
+				Left:              left,
+				Right:             right,
+				Variable:          variable,
+				KeyExpression:     fmt.Sprintf(`%s := fmt.Sprintf("%s%s", %s,%s)`, variable, "%s", "%v", left, lowerStartCamelFieldName),
+				DataKeyExpression: fmt.Sprintf(`%s := fmt.Sprintf("%s%s",%s, data.%s)`, variable, "%s", "%v", left, camelFieldName),
+				RespKeyExpression: fmt.Sprintf(`%s := fmt.Sprintf("%s%s", %s,resp.%s)`, variable, "%s", "%v", left, camelFieldName),
+			}
 		}
 	}
 	return m, nil

--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -36,6 +36,7 @@ type (
 		DataType     string
 		IsKey        bool
 		IsPrimaryKey bool
+		IsUniqueKey  bool
 		Comment      string
 	}
 
@@ -124,6 +125,7 @@ func Parse(ddl string) (*Table, error) {
 		if ok {
 			field.IsKey = true
 			field.IsPrimaryKey = key == primary
+			field.IsUniqueKey = key == unique
 			if field.IsPrimaryKey {
 				primaryKey.Field = field
 				if column.Type.Autoincrement {


### PR DESCRIPTION
> findOneByField() 之前包含了unique、normal、spatial三类索引处理

* 修改后：只处理unique索引