### PR TITLE
fix example tracing edge config

### DIFF
--- a/example/tracing/edge/config.json
+++ b/example/tracing/edge/config.json
@@ -1,3 +1,13 @@
 {
-    "Server": "localhost:3456"
+  "Name": "edge-api",
+  "Host": "0.0.0.0",
+  "Port": 3456,
+  "Portal": {
+    "Etcd": {
+      "Hosts": [
+        "localhost:2379"
+      ],
+      "Key": "portal"
+    }
+  }
 }

--- a/example/tracing/edge/main.go
+++ b/example/tracing/edge/main.go
@@ -18,6 +18,11 @@ var (
 	client     rpcx.Client
 )
 
+type Config struct {
+	rest.RestConf
+	Portal rpcx.RpcClientConf
+}
+
 func handle(w http.ResponseWriter, r *http.Request) {
 	conn := client.Conn()
 	greet := portal.NewPortalClient(conn)
@@ -34,16 +39,16 @@ func handle(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	var c rpcx.RpcClientConf
+	var c Config
 	conf.MustLoad(*configFile, &c)
-	client = rpcx.MustNewClient(c)
+	client = rpcx.MustNewClient(c.Portal)
 	engine := rest.MustNewServer(rest.RestConf{
 		ServiceConf: service.ServiceConf{
 			Log: logx.LogConf{
 				Mode: "console",
 			},
 		},
-		Port: 3333,
+		Port: c.Port,
 	})
 	defer engine.Stop()
 


### PR DESCRIPTION
1.补上一些缺失的配置
2.原配置中的api端口号与代码中不一致（写死）