### PR TITLE
fix rpc client example

### DIFF
--- a/example/rpc/client/stream/client.go
+++ b/example/rpc/client/stream/client.go
@@ -33,8 +33,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	done := make(chan struct{})
 	go func() {
-		for {
+		defer func() {
+			done <- struct{}{}
+		}()
+		for i := 0; i < 3; i++ {
 			resp, err := stm.Recv()
 			if err != nil {
 				log.Fatal(err)
@@ -52,4 +56,6 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+
+	<-done
 }


### PR DESCRIPTION
1.原来接收Recv的协程是个死循环。
2.main在Send三次后直接退出了，看不到Recv的输出。