### PR TITLE
fix: golint: context.WithValue should should not use basic type as key

### DIFF
--- a/core/trace/tracespec/vars.go
+++ b/core/trace/tracespec/vars.go
@@ -1,4 +1,7 @@
 package tracespec
 
+//ContextKey a type for context key
+type ContextKey struct{}
+
 //TracingKey is tracing key for ctx
-var TracingKey struct{}
+var TracingKey ContextKey

--- a/core/trace/tracespec/vars.go
+++ b/core/trace/tracespec/vars.go
@@ -1,3 +1,4 @@
 package tracespec
 
-const TracingKey = "X-Trace"
+//TracingKey is tracing key for ctx
+var TracingKey struct{}


### PR DESCRIPTION
should not use basic type string as key in context.WithValue,

context.WithValue method Doc:

```
// The provided key must be comparable and should not be of type
// string or any other built-in type to avoid collisions between
// packages using context. Users of WithValue should define their own
// types for keys. To avoid allocating when assigning to an
// interface{}, context keys often have concrete type
// struct{}. Alternatively, exported context key variables' static
// type should be a pointer or interface.
```