### PR TITLE
optimiz: equal code for simple

### DIFF
--- a/core/proc/env.go
+++ b/core/proc/env.go
@@ -30,14 +30,9 @@ func Env(name string) string {
 
 func EnvInt(name string) (int, bool) {
 	val := Env(name)
-	if len(val) == 0 {
-		return 0, false
-	}
-
 	n, err := strconv.Atoi(val)
 	if err != nil {
 		return 0, false
 	}
-
 	return n, true
 }


### PR DESCRIPTION
strconv.Atoi return int zero value with a error (parsing "": invalid syntax)

```
n, err := strconv.Atoi("")
//got values: 0, error(parsing "": invalid syntax)
```

so this  is equivalent code.