### PR TITLE
修复阿里云集群 redis KEYS 的错误。

### DIFF
--- a/core/bloom/bloom.go
+++ b/core/bloom/bloom.go
@@ -13,15 +13,13 @@ const (
 	// maps as k in the error rate table
 	maps      = 14
 	setScript = `
-local key = KEYS[1]
 for _, offset in ipairs(ARGV) do
-	redis.call("setbit", key, offset, 1)
+	redis.call("setbit", KEYS[1], offset, 1)
 end
 `
 	testScript = `
-local key = KEYS[1]
 for _, offset in ipairs(ARGV) do
-	if tonumber(redis.call("getbit", key, offset)) == 0 then
+	if tonumber(redis.call("getbit", KEYS[1], offset)) == 0 then
 		return false
 	end
 end


### PR DESCRIPTION
参考 https://help.aliyun.com/document_detail/92942.html?spm=5176.13910061.sslink.1.36426f0dV6cOrU
阿里云的文档，如果按照以前的写法会出现如下错误
```bash
 redis cluster, all the keys that the script uses should be passed using the KEYS arrayrn
```