### PR TITLE
stop rpc server when main function exit

### DIFF
--- a/tools/goctl/rpc/gen/genmain.go
+++ b/tools/goctl/rpc/gen/genmain.go
@@ -39,6 +39,7 @@ func main() {
 		{{.registers}}
 	})
 	logx.Must(err)
+	defer s.Stop()
 
 	fmt.Printf("Starting rpc server at %s...\n", c.ListenOn)
 	s.Start()


### PR DESCRIPTION
add defer s.Stop() to mainTemplate, in order to stop rpc server when main function exit