### PR TITLE
fix: fx/fn.Head func will forever block when n is less than 1

### DIFF
--- a/core/fx/fn.go
+++ b/core/fx/fn.go
@@ -159,6 +159,9 @@ func (p Stream) Group(fn KeyFunc) Stream {
 }
 
 func (p Stream) Head(n int64) Stream {
+	if n < 1 {
+		panic("n must be greater than 0")
+	}
 	source := make(chan interface{})
 
 	go func() {

--- a/core/fx/fn_test.go
+++ b/core/fx/fn_test.go
@@ -167,6 +167,9 @@ func TestHead(t *testing.T) {
 		return result, nil
 	})
 	assert.Equal(t, 3, result)
+	assert.Panics(t, func() {
+		Just(1, 2, 3, 4).Head(0)
+	})
 }
 
 func TestHeadMore(t *testing.T) {

--- a/core/fx/fn_test.go
+++ b/core/fx/fn_test.go
@@ -167,8 +167,17 @@ func TestHead(t *testing.T) {
 		return result, nil
 	})
 	assert.Equal(t, 3, result)
+}
+
+func TestHeadZero(t *testing.T) {
 	assert.Panics(t, func() {
-		Just(1, 2, 3, 4).Head(0)
+		var result int
+		Just(1, 2, 3, 4).Head(0).Reduce(func(pipe <-chan interface{}) (interface{}, error) {
+			for item := range pipe {
+				result += item.(int)
+			}
+			return result, nil
+		})
 	})
 }
 

--- a/core/fx/fn_test.go
+++ b/core/fx/fn_test.go
@@ -171,12 +171,8 @@ func TestHead(t *testing.T) {
 
 func TestHeadZero(t *testing.T) {
 	assert.Panics(t, func() {
-		var result int
 		Just(1, 2, 3, 4).Head(0).Reduce(func(pipe <-chan interface{}) (interface{}, error) {
-			for item := range pipe {
-				result += item.(int)
-			}
-			return result, nil
+			return nil, nil
 		})
 	})
 }


### PR DESCRIPTION
When n is less than 1 , fx/Stream Head func will forever block , this pull request will fix it.