### PR TITLE
goctl add stdin flag

### DIFF
--- a/tools/goctl/api/format/format.go
+++ b/tools/goctl/api/format/format.go
@@ -35,7 +35,6 @@ func GoFormatApi(c *cli.Context) error {
 		if len(dir) == 0 {
 			return errors.New("missing -dir")
 		}
-		var be errorx.BatchError
 		err := filepath.Walk(dir, func(path string, fi os.FileInfo, errBack error) (err error) {
 			if strings.HasSuffix(path, ".api") {
 				if err := ApiFormatByPath(path); err != nil {

--- a/tools/goctl/api/format/format.go
+++ b/tools/goctl/api/format/format.go
@@ -35,7 +35,13 @@ func GoFormatApi(c *cli.Context) error {
 		if len(dir) == 0 {
 			return errors.New("missing -dir")
 		}
-		err := filepath.Walk(dir, func(path string, fi os.FileInfo, errBack error) (err error) {
+
+		_, err := os.Lstat(dir)
+		if err != nil {
+			return errors.New(dir + ": No such file or directory")
+		}
+
+		err = filepath.Walk(dir, func(path string, fi os.FileInfo, errBack error) (err error) {
 			if strings.HasSuffix(path, ".api") {
 				if err := ApiFormatByPath(path); err != nil {
 					be.Add(util.WrapErr(err, fi.Name()))

--- a/tools/goctl/api/gogen/gen.go
+++ b/tools/goctl/api/gogen/gen.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -67,17 +66,7 @@ func DoGenProject(apiFile, dir string, force bool) error {
 		return err
 	}
 
-	data, err := ioutil.ReadFile(apiFile)
-	if err != nil {
-		return err
-	}
-
-	result, err := apiformat.ApiFormat(string(data))
-	if err != nil {
-		return err
-	}
-
-	if err := ioutil.WriteFile(apiFile, []byte(result), os.ModePerm); err != nil {
+	if err := apiformat.ApiFormatByPath(apiFile); err != nil {
 		return err
 	}
 

--- a/tools/goctl/api/gogen/gen.go
+++ b/tools/goctl/api/gogen/gen.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -66,7 +67,17 @@ func DoGenProject(apiFile, dir string, force bool) error {
 		return err
 	}
 
-	if err = apiformat.ApiFormat(apiFile, false); err != nil {
+	data, err := ioutil.ReadFile(apiFile)
+	if err != nil {
+		return err
+	}
+
+	result, err := apiformat.ApiFormat(string(data))
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(apiFile, []byte(result), os.ModePerm); err != nil {
 		return err
 	}
 

--- a/tools/goctl/goctl.go
+++ b/tools/goctl/goctl.go
@@ -52,12 +52,13 @@ var (
 							Usage: "the format target dir",
 						},
 						cli.BoolFlag{
-							Name:  "p",
-							Usage: "print result to console",
-						},
-						cli.BoolFlag{
 							Name:     "iu",
 							Usage:    "ignore update",
+							Required: false,
+						},
+						cli.BoolFlag{
+							Name:     "stdin",
+							Usage:    "use stdin to input api doc content, press \"ctrl + d\" to send EOF",
 							Required: false,
 						},
 					},


### PR DESCRIPTION
Add stdin flag to use stdin receive api doc and use stdout output formatted result.

This pull request can make the vscode-goctl extension not need to flash the api file to the disk when formatting.

@kingxt  @anqiansong 