### PR TITLE
main.tpl, etc.tpl template gen filename by ***.api; ***.go, ***.yaml

### DIFF
--- a/tools/goctl/api/gogen/genetc.go
+++ b/tools/goctl/api/gogen/genetc.go
@@ -21,7 +21,7 @@ Port: {{.port}}
 )
 
 func genEtc(dir string, api *spec.ApiSpec) error {
-	fp, created, err := util.MaybeCreateFile(dir, etcDir, fmt.Sprintf("%s.yaml", api.Service.Name))
+	fp, created, err := util.MaybeCreateFile(dir, etcDir, fmt.Sprintf("%s.yaml", api.Info.ApiFileName))
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func genEtc(dir string, api *spec.ApiSpec) error {
 	t := template.Must(template.New("etcTemplate").Parse(text))
 	buffer := new(bytes.Buffer)
 	err = t.Execute(buffer, map[string]string{
-		"serviceName": service.Name,
+		"serviceName": api.Info.ApiFileName,
 		"host":        host,
 		"port":        port,
 	})

--- a/tools/goctl/api/gogen/genmain.go
+++ b/tools/goctl/api/gogen/genmain.go
@@ -41,7 +41,7 @@ func main() {
 `
 
 func genMain(dir string, api *spec.ApiSpec) error {
-	name := strings.ToLower(api.Service.Name)
+	name := strings.ToLower(api.Info.ApiFileName)
 	if strings.HasSuffix(name, "-api") {
 		name = strings.ReplaceAll(name, "-api", "")
 	}
@@ -69,7 +69,7 @@ func genMain(dir string, api *spec.ApiSpec) error {
 	buffer := new(bytes.Buffer)
 	err = t.Execute(buffer, map[string]string{
 		"importPackages": genMainImports(parentPkg),
-		"serviceName":    api.Service.Name,
+		"serviceName":    api.Info.ApiFileName,
 	})
 	if err != nil {
 		return nil

--- a/tools/goctl/api/parser/parser.go
+++ b/tools/goctl/api/parser/parser.go
@@ -14,9 +14,10 @@ import (
 )
 
 type Parser struct {
-	r       *bufio.Reader
-	typeDef string
-	api     *ApiStruct
+	r           *bufio.Reader
+	typeDef     string
+	api         *ApiStruct
+	apiFileName string
 }
 
 func NewParser(filename string) (*Parser, error) {
@@ -24,6 +25,8 @@ func NewParser(filename string) (*Parser, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	apiFileName := util.FileBaseNameWithoutExt(filename)
 
 	api, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -54,9 +57,10 @@ func NewParser(filename string) (*Parser, error) {
 	var buffer = new(bytes.Buffer)
 	buffer.WriteString(apiStruct.Service)
 	return &Parser{
-		r:       bufio.NewReader(buffer),
-		typeDef: apiStruct.StructBody,
-		api:     apiStruct,
+		r:           bufio.NewReader(buffer),
+		typeDef:     apiStruct.StructBody,
+		api:         apiStruct,
+		apiFileName: apiFileName,
 	}, nil
 }
 
@@ -68,6 +72,7 @@ func (p *Parser) Parse() (api *spec.ApiSpec, err error) {
 		return nil, err
 	}
 	api.Types = types
+	api.Info.ApiFileName = p.apiFileName
 	var lineNumber = p.api.serviceBeginLine
 	st := newRootState(p.r, &lineNumber)
 	for {

--- a/tools/goctl/api/spec/spec.go
+++ b/tools/goctl/api/spec/spec.go
@@ -19,11 +19,12 @@ type (
 	}
 
 	Info struct {
-		Title   string
-		Desc    string
-		Version string
-		Author  string
-		Email   string
+		ApiFileName string
+		Title       string
+		Desc        string
+		Version     string
+		Author      string
+		Email       string
 	}
 
 	Member struct {

--- a/tools/goctl/util/file.go
+++ b/tools/goctl/util/file.go
@@ -51,3 +51,10 @@ func FileExists(file string) bool {
 func FileNameWithoutExt(file string) string {
 	return strings.TrimSuffix(file, filepath.Ext(file))
 }
+
+// Name returns the last element of path without file extension.
+// Example:
+// main.go          -> main
+func FileBaseNameWithoutExt(path string) string {
+	return FileNameWithoutExt(filepath.Base(path))
+}

--- a/tools/goctl/util/file_test.go
+++ b/tools/goctl/util/file_test.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileBaseNameWithoutExt(t *testing.T) {
+	var filePath = "cmd/api/bookstore.api"
+	fileName := FileBaseNameWithoutExt(filePath)
+	assert.Equal(t, "bookstore", fileName)
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5088165/97284539-1e66d880-187c-11eb-9ce5-c5b5e5cbc000.png)
当api有多个service的时候，生成main.go， ***.yaml以最后一个serviceName为文件名
![image](https://user-images.githubusercontent.com/5088165/97284656-48b89600-187c-11eb-9c51-1467f74acf9c.png)
![image](https://user-images.githubusercontent.com/5088165/97284960-a0570180-187c-11eb-8251-36ef9bbc9cc4.png)

建议使用 bookstore.api  api的文件名bookstore为生成的文件名，修改后生成的文件名：
![image](https://user-images.githubusercontent.com/5088165/97285200-e318d980-187c-11eb-97ae-dafad77ffbac.png)

