### PR TITLE
Improve Makefile robustness

### DIFF
--- a/tools/goctl/Makefile
+++ b/tools/goctl/Makefile
@@ -2,13 +2,13 @@ version := $(shell /bin/date "+%Y-%m-%d %H:%M")
 
 build:
 	go build -ldflags="-s -w" -ldflags="-X 'main.BuildTime=$(version)'" goctl.go
-	command -v upx &> /dev/null && upx goctl
+	$(if $(shell command -v upx),upx goctl)
 mac:
 	GOOS=darwin go build -ldflags="-s -w" -ldflags="-X 'main.BuildTime=$(version)'" -o goctl-darwin goctl.go
-	command -v upx &> /dev/null && upx goctl-darwin
+	$(if $(shell command -v upx),upx goctl-darwin)
 win:
 	GOOS=windows go build -ldflags="-s -w" -ldflags="-X 'main.BuildTime=$(version)'" -o goctl.exe goctl.go
-	command -v upx &> /dev/null && upx goctl.exe
+	$(if $(shell command -v upx),upx goctl.exe)
 linux:
 	GOOS=linux go build -ldflags="-s -w" -ldflags="-X 'main.BuildTime=$(version)'" -o goctl-linux goctl.go
-	command -v upx &> /dev/null && upx goctl-linux
+	$(if $(shell command -v upx),upx goctl-linux)


### PR DESCRIPTION
### 问题描述：
- `command -v upx &> /dev/null && upx goctl`这样的写法无法达到预期的目的（若已安装upx则执行upx goctl）。若实际未安装upx，执行这条指令报错。

### 复现方案
- 方式一：卸载upx，再执行make。
- 方式二: 重置`PATH`环境变量，将upx所在目录（如`/usr/local/bin`）排除在PATH环境变量之外，再执行make。

### 修复方案
- 使用Makefile的`if`函数判断upx是否已经安装，若已经安装，则执行upx goctl。