### PR TITLE
fix tracelogger_test TestTraceLog

### DIFF
--- a/core/logx/tracelogger_test.go
+++ b/core/logx/tracelogger_test.go
@@ -21,6 +21,7 @@ var mock tracespec.Trace = new(mockTrace)
 
 func TestTraceLog(t *testing.T) {
 	var buf mockWriter
+	atomic.StoreUint32(&initialized, 1)
 	ctx := context.WithValue(context.Background(), tracespec.TracingKey, mock)
 	WithContext(ctx).(*traceLogger).write(&buf, levelInfo, testlog)
 	assert.True(t, strings.Contains(buf.String(), mockTraceId))


### PR DESCRIPTION
tracelogger_test.go 中 TestTraceLog 测试失败，没有初始化 initialized 变量为 1，导致测试不通过


Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestTraceLog$ github.com/tal-tech/go-zero/core/logx

2020/12/10 15:18:14 {"@timestamp":"2020-12-10T15:18:14.825+08","level":"info","content":"Stay hungry, stay foolish.","trace":"mock-trace-id","span":"mock-span-id"}
--- FAIL: TestTraceLog (0.00s)
    /Users/wayne/learning-projects/go-learn/github-projects/tal-tech-go-zero/core/logx/tracelogger_test.go:26: 
        	Error Trace:	tracelogger_test.go:26
        	Error:      	Should be true
        	Test:       	TestTraceLog
    /Users/wayne/learning-projects/go-learn/github-projects/tal-tech-go-zero/core/logx/tracelogger_test.go:27: 
        	Error Trace:	tracelogger_test.go:27
        	Error:      	Should be true
        	Test:       	TestTraceLog
FAIL
FAIL	github.com/tal-tech/go-zero/core/logx	0.309s
FAIL