### PR TITLE
add api syntax version

### DIFF
--- a/tools/goctl/api/gogen/gen_test.go
+++ b/tools/goctl/api/gogen/gen_test.go
@@ -320,7 +320,64 @@ service A-api {
 `
 
 const syntaxApi = `
-syntax:"v2"
+syntax = "v2"
+
+type Request struct {
+  Name string ` + "`" + `path:"name,options=you|me"` + "`" + `
+}
+
+type Response struct {
+  Message string ` + "`" + `json:"message"` + "`" + ` // message
+}
+
+service A-api {
+  @server(
+    handler: GreetHandler
+  )
+  get /greet/from/:name(Request) returns (Response)
+}
+`
+
+const errTokenSyntaxApi = `
+synta = "v2"
+
+type Request struct {
+  Name string ` + "`" + `path:"name,options=you|me"` + "`" + `
+}
+
+type Response struct {
+  Message string ` + "`" + `json:"message"` + "`" + ` // message
+}
+
+service A-api {
+  @server(
+    handler: GreetHandler
+  )
+  get /greet/from/:name(Request) returns (Response)
+}
+`
+
+const errSyntaxVersionApi = `
+syntax = "2"
+
+type Request struct {
+  Name string ` + "`" + `path:"name,options=you|me"` + "`" + `
+}
+
+type Response struct {
+  Message string ` + "`" + `json:"message"` + "`" + ` // message
+}
+
+service A-api {
+  @server(
+    handler: GreetHandler
+  )
+  get /greet/from/:name(Request) returns (Response)
+}
+`
+
+const errSyntaxVersionNumberApi = `
+syntax : "v2"
 
 type Request struct {
   Name string ` + "`" + `path:"name,options=you|me"` + "`" + `
@@ -356,7 +413,7 @@ service A-api {
 `
 
 const syntaxHasImportApi = `
-syntax: "v2"
+syntax = "v2"
 
 import "test3.api"
 
@@ -667,6 +724,36 @@ func TestSyntax(t *testing.T) {
 	_, err = parser.NewParser(filename)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "deplicate api syntax")
+
+	filename = filepath.Join(t.TempDir(), "test5.api")
+	err = ioutil.WriteFile(filename, []byte(errTokenSyntaxApi), os.ModePerm)
+	assert.Nil(t, err)
+
+	_, err = parser.NewParser(filename)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid token")
+
+	filename = filepath.Join(t.TempDir(), "test6.api")
+	err = ioutil.WriteFile(filename, []byte(errSyntaxVersionApi), os.ModePerm)
+	assert.Nil(t, err)
+
+	p, err = parser.NewParser(filename)
+	assert.Nil(t, err)
+
+	_, err = p.Parse()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected version after")
+
+	filename = filepath.Join(t.TempDir(), "test7.api")
+	err = ioutil.WriteFile(filename, []byte(errSyntaxVersionNumberApi), os.ModePerm)
+	assert.Nil(t, err)
+
+	p, err = parser.NewParser(filename)
+	assert.Nil(t, err)
+
+	_, err = p.Parse()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected '='")
 }
 
 func validate(t *testing.T, api string) {

--- a/tools/goctl/api/parser/apifileparser.go
+++ b/tools/goctl/api/parser/apifileparser.go
@@ -91,7 +91,7 @@ func (s *apiRootState) process(api *ApiStruct, _ string) (apiFileState, error) {
 		}
 
 		switch {
-		case isSpace(ch) || isNewline(ch) || ch == leftParenthesis || ch == colon:
+		case isSpace(ch) || isNewline(ch) || ch == leftParenthesis || ch == equalSemi:
 			token := builder.String()
 			token = strings.TrimSpace(token)
 			if len(token) == 0 {

--- a/tools/goctl/api/parser/parser.go
+++ b/tools/goctl/api/parser/parser.go
@@ -72,7 +72,7 @@ func NewParser(filename string) (*Parser, error) {
 			}
 
 			if apiStruct.Syntax != importStruct.Syntax {
-				return nil, fmt.Errorf("deplicate api syntax: %s,%s", apiStruct.Syntax, importStruct.Syntax)
+				return nil, fmt.Errorf("inconsistent api syntax: %s,%s", apiStruct.Syntax, importStruct.Syntax)
 			}
 
 			apiStruct.Type += "\n" + importStruct.Type

--- a/tools/goctl/api/parser/parser.go
+++ b/tools/goctl/api/parser/parser.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tal-tech/go-zero/tools/goctl/util"
 )
 
-const defaultSyntax = `syntax: "v1"`
+const defaultSyntax = `syntax = "v1"`
 
 type Parser struct {
 	r   *bufio.Reader

--- a/tools/goctl/api/parser/syntaxstate.go
+++ b/tools/goctl/api/parser/syntaxstate.go
@@ -1,0 +1,63 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/tal-tech/go-zero/tools/goctl/api/spec"
+)
+
+type syntaxState struct {
+	syntax string
+}
+
+func newSyntaxState(syntax string) *syntaxState {
+	return &syntaxState{
+		syntax: syntax,
+	}
+}
+
+func (s *syntaxState) process() (string, error) {
+	s.syntax = strings.ReplaceAll(s.syntax, `"`, "")
+	colonIndex := strings.Index(s.syntax, ":")
+	if colonIndex <= 0 {
+		return "", errors.New("expected ':' near syntax")
+	}
+
+	flagVIndex := strings.Index(s.syntax, "v")
+	if flagVIndex < 0 {
+		return "", errors.New("expected version spec after ':'")
+	}
+
+	version := s.syntax[flagVIndex:]
+	versionNumber := strings.TrimPrefix(version, "v")
+	_, err := strconv.ParseUint(versionNumber, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("expected version spec after ':', but found %s", version)
+	}
+
+	return version, nil
+}
+
+func (s *syntaxState) writeInfo(api *spec.ApiSpec, attrs map[string]string) error {
+	for k, v := range attrs {
+		switch k {
+		case titleTag:
+			api.Info.Title = strings.TrimSpace(v)
+		case descTag:
+			api.Info.Desc = strings.TrimSpace(v)
+		case versionTag:
+			api.Info.Version = strings.TrimSpace(v)
+		case authorTag:
+			api.Info.Author = strings.TrimSpace(v)
+		case emailTag:
+			api.Info.Email = strings.TrimSpace(v)
+		default:
+			return fmt.Errorf("unknown directive %q in %q section", k, infoDirective)
+		}
+	}
+
+	return nil
+}

--- a/tools/goctl/api/parser/syntaxstate.go
+++ b/tools/goctl/api/parser/syntaxstate.go
@@ -1,12 +1,9 @@
 package parser
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/tal-tech/go-zero/tools/goctl/api/spec"
 )
 
 type syntaxState struct {
@@ -20,44 +17,31 @@ func newSyntaxState(syntax string) *syntaxState {
 }
 
 func (s *syntaxState) process() (string, error) {
-	s.syntax = strings.ReplaceAll(s.syntax, `"`, "")
-	colonIndex := strings.Index(s.syntax, ":")
-	if colonIndex <= 0 {
-		return "", errors.New("expected ':' near syntax")
+	fields := strings.Fields(s.syntax)
+	if len(fields) != 3 {
+		return "", fmt.Errorf("expected syntax, but found %s", s.syntax)
 	}
 
-	flagVIndex := strings.Index(s.syntax, "v")
-	if flagVIndex < 0 {
-		return "", errors.New("expected version spec after ':'")
+	if fields[0] != tokenSyntax {
+		return "", fmt.Errorf("expected syntax, but found %s", fields[0])
 	}
 
-	version := s.syntax[flagVIndex:]
+	if fields[1] != "=" {
+		return "", fmt.Errorf("expected '=' after syntax, but found %s", fields[1])
+	}
+
+	version := fields[2]
+	version = strings.TrimPrefix(version, `"`)
+	version = strings.TrimSuffix(version, `"`)
+	if !strings.HasPrefix(version, "v") {
+		return "", fmt.Errorf("expected version after '=', but found %s", version)
+	}
+
 	versionNumber := strings.TrimPrefix(version, "v")
 	_, err := strconv.ParseUint(versionNumber, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("expected version spec after ':', but found %s", version)
+		return "", fmt.Errorf("expected version after '=', but found %s", version)
 	}
 
 	return version, nil
-}
-
-func (s *syntaxState) writeInfo(api *spec.ApiSpec, attrs map[string]string) error {
-	for k, v := range attrs {
-		switch k {
-		case titleTag:
-			api.Info.Title = strings.TrimSpace(v)
-		case descTag:
-			api.Info.Desc = strings.TrimSpace(v)
-		case versionTag:
-			api.Info.Version = strings.TrimSpace(v)
-		case authorTag:
-			api.Info.Author = strings.TrimSpace(v)
-		case emailTag:
-			api.Info.Email = strings.TrimSpace(v)
-		default:
-			return fmt.Errorf("unknown directive %q in %q section", k, infoDirective)
-		}
-	}
-
-	return nil
 }

--- a/tools/goctl/api/parser/vars.go
+++ b/tools/goctl/api/parser/vars.go
@@ -8,6 +8,7 @@ const (
 	routeSyntax       = "route syntax: [get/post/delete] /path(request) returns[(response)]"
 	returnsTag        = "returns"
 	at                = '@'
+	equalSemi         = '='
 	colon             = ':'
 	leftParenthesis   = '('
 	rightParenthesis  = ')'

--- a/tools/goctl/api/spec/spec.go
+++ b/tools/goctl/api/spec/spec.go
@@ -8,6 +8,7 @@ type (
 	}
 
 	ApiSpec struct {
+		Syntax  string
 		Info    Info
 		Types   []Type
 		Service Service


### PR DESCRIPTION
In order to better support api extension,Now Add optional syntax,
* expression
```syntax="$version"```

`$version`: the api version , which value such as `v1`、`v2`，default is `v1`

> Note: api file only can import another api files which have the same syntax version