### PR TITLE
add config load support env var

### DIFF
--- a/core/conf/config.go
+++ b/core/conf/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path"
 
 	"github.com/tal-tech/go-zero/core/mapping"
@@ -19,7 +20,7 @@ func LoadConfig(file string, v interface{}) error {
 	if content, err := ioutil.ReadFile(file); err != nil {
 		return err
 	} else if loader, ok := loaders[path.Ext(file)]; ok {
-		return loader(content, v)
+		return loader([]byte(os.ExpandEnv(string(content))), v)
 	} else {
 		return fmt.Errorf("unrecoginized file type: %s", file)
 	}

--- a/core/conf/config_test.go
+++ b/core/conf/config_test.go
@@ -17,13 +17,15 @@ func TestConfigJson(t *testing.T) {
 	}
 	text := `{
 	"a": "foo",
-	"b": 1
+	"b": 1,
+	"c": "${FOO}"
 }`
 	for _, test := range tests {
 		test := test
 		t.Run(test, func(t *testing.T) {
 			t.Parallel()
-
+			os.Setenv("FOO", "2")
+			defer os.Unsetenv("FOO")
 			tmpfile, err := createTempFile(test, text)
 			assert.Nil(t, err)
 			defer os.Remove(tmpfile)
@@ -31,10 +33,12 @@ func TestConfigJson(t *testing.T) {
 			var val struct {
 				A string `json:"a"`
 				B int    `json:"b"`
+				C string    `json:"c"`
 			}
 			MustLoad(tmpfile, &val)
 			assert.Equal(t, "foo", val.A)
 			assert.Equal(t, 1, val.B)
+			assert.Equal(t, "2", val.C)
 		})
 	}
 }


### PR DESCRIPTION
增加在配置文件加载时，可以从环境变量中加载相关信息，便于保护私密信息

原有代码：
```go
return loader(content, v)
```
修改后:
```go
return loader([]byte(os.ExpandEnv(string(content))), v)
```

相关的test也修改了,具体参考commit文件
