### PR TITLE
The ResponseWriters defined in rest.handler add Flush interface.

### DIFF
--- a/rest/handler/authhandler.go
+++ b/rest/handler/authhandler.go
@@ -138,3 +138,9 @@ func (grw *guardedResponseWriter) WriteHeader(statusCode int) {
 	grw.wroteHeader = true
 	grw.writer.WriteHeader(statusCode)
 }
+
+func (grw *guardedResponseWriter) Flush() {
+	if flusher, ok := grw.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/rest/handler/authhandler_test.go
+++ b/rest/handler/authhandler_test.go
@@ -41,6 +41,10 @@ func TestAuthHandler(t *testing.T) {
 			w.Header().Set("X-Test", "test")
 			_, err := w.Write([]byte("content"))
 			assert.Nil(t, err)
+
+			flusher, ok := w.(http.Flusher)
+			assert.Equal(t, ok, true)
+			flusher.Flush()
 		}))
 
 	resp := httptest.NewRecorder()

--- a/rest/handler/cryptionhandler.go
+++ b/rest/handler/cryptionhandler.go
@@ -95,6 +95,12 @@ func (w *cryptionResponseWriter) WriteHeader(statusCode int) {
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
+func (w *cryptionResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 func (w *cryptionResponseWriter) flush(key []byte) {
 	if w.buf.Len() == 0 {
 		return

--- a/rest/handler/cryptionhandler_test.go
+++ b/rest/handler/cryptionhandler_test.go
@@ -87,3 +87,20 @@ func TestCryptionHandlerWriteHeader(t *testing.T) {
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 }
+
+func TestCryptionHandlerFlush(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/any", nil)
+	handler := CryptionHandler(aesKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(respText))
+
+		flusher, ok := w.(http.Flusher)
+		assert.Equal(t, ok, true)
+		flusher.Flush()
+	}))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	expect, err := codec.EcbEncrypt(aesKey, []byte(respText))
+	assert.Nil(t, err)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(expect), recorder.Body.String())
+}

--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -38,6 +38,12 @@ func (w *LoggedResponseWriter) WriteHeader(code int) {
 	w.code = code
 }
 
+func (w *LoggedResponseWriter) Flush() {
+	if flusher, ok := w.w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 func LogHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		timer := utils.NewElapsedTimer()
@@ -79,6 +85,12 @@ func (w *DetailLoggedResponseWriter) Write(bs []byte) (int, error) {
 
 func (w *DetailLoggedResponseWriter) WriteHeader(code int) {
 	w.writer.WriteHeader(code)
+}
+
+func (w *DetailLoggedResponseWriter) Flush() {
+	if flusher, ok := http.ResponseWriter(w.writer).(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 func DetailedLogHandler(next http.Handler) http.Handler {

--- a/rest/handler/loghandler_test.go
+++ b/rest/handler/loghandler_test.go
@@ -30,6 +30,10 @@ func TestLogHandler(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, err := w.Write([]byte("content"))
 			assert.Nil(t, err)
+
+			flusher, ok := w.(http.Flusher)
+			assert.Equal(t, ok, true)
+			flusher.Flush()
 		}))
 
 		resp := httptest.NewRecorder()

--- a/rest/internal/security/withcoderesponsewriter.go
+++ b/rest/internal/security/withcoderesponsewriter.go
@@ -19,3 +19,9 @@ func (w *WithCodeResponseWriter) WriteHeader(code int) {
 	w.Writer.WriteHeader(code)
 	w.Code = code
 }
+
+func (w *WithCodeResponseWriter) Flush() {
+	if flusher, ok := w.Writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/rest/internal/security/withcoderesponsewriter_test.go
+++ b/rest/internal/security/withcoderesponsewriter_test.go
@@ -1,0 +1,33 @@
+package security
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithCodeResponseWriter(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cw := &WithCodeResponseWriter{Writer: w}
+
+		cw.Header().Set("X-Test", "test")
+		cw.WriteHeader(http.StatusServiceUnavailable)
+		assert.Equal(t, cw.Code, http.StatusServiceUnavailable)
+
+		_, err := cw.Write([]byte("content"))
+		assert.Nil(t, err)
+
+		flusher, ok := http.ResponseWriter(cw).(http.Flusher)
+		assert.Equal(t, ok, true)
+		flusher.Flush()
+	})
+
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.Code)
+	assert.Equal(t, "test", resp.Header().Get("X-Test"))
+	assert.Equal(t, "content", resp.Body.String())
+}


### PR DESCRIPTION
## feature
- To support http.Flush

## test
### test code
> source code : https://github.com/jichangyun/bookstore
```
func (l *CheckLogic) Check(w http.ResponseWriter, req types.CheckReq) (*types.CheckResp, error) {
	flusher, ok := w.(http.Flusher)
	if !ok {
		l.Logger.Errorf("Writer is not a Flusher. w: %v.", w)
		return nil, errors.New("ResponseWriter unsupport Flusher!")
	}

	// 先返回头部信息
	w.Header().Set("Content-Type", "application/json")
	w.Header().Set("Transfer-Encoding", "chunked")
	w.WriteHeader(http.StatusOK)
	flusher.Flush()
	
	fmt.Fprintf(w, "Start return value.\n")
	flusher.Flush()

	for i := 0; i < 5; i++ {
		time.Sleep(time.Duration(i) * time.Second)
		fmt.Fprintf(w, "Return value %d after sleep %d second.\n", i, i)
		flusher.Flush()
	}

	return &types.CheckResp{}, nil
}
```
### test result
- Use chorme to visit `http://localhost:8888/check?book=go-zero`
- Chorme output
```
Start return value.
Return value 0 after sleep 0 second.
Return value 1 after sleep 1 second.
Return value 2 after sleep 2 second.
Return value 3 after sleep 3 second.
Return value 4 after sleep 4 second.
{"found":false,"price":0}
```
- PS：The text of "Return value 1-4" show in turn, not all at once.
