### PR TITLE
modify the goctl gensvc template

### DIFF
--- a/tools/goctl/rpc/generator/gensvc.go
+++ b/tools/goctl/rpc/generator/gensvc.go
@@ -15,12 +15,12 @@ const svcTemplate = `package svc
 import {{.imports}}
 
 type ServiceContext struct {
-	c config.Config
+	Config config.Config
 }
 
 func NewServiceContext(c config.Config) *ServiceContext {
 	return &ServiceContext{
-		c:c,
+		Config:c,
 	}
 }
 `


### PR DESCRIPTION
rpc中的config不是公开的
api中的config是公开的
这里修改了rpc中的生成模板，进行统一