### PR TITLE
outputJson 方法json marshal改为encode ，不转义html字符(例如：&)

### DIFF
--- a/core/logx/logs.go
+++ b/core/logx/logs.go
@@ -1,6 +1,7 @@
 package logx
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -352,12 +353,16 @@ func outputError(writer io.Writer, msg string, callDepth int) {
 }
 
 func outputJson(writer io.Writer, info interface{}) {
-	if content, err := json.Marshal(info); err != nil {
+	jsonBuf := new(bytes.Buffer)
+	enc := json.NewEncoder(jsonBuf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(info)
+	if err != nil{
 		log.Println(err.Error())
 	} else if atomic.LoadUint32(&initialized) == 0 || writer == nil {
-		log.Println(string(content))
+		log.Println(string(jsonBuf.Bytes()))
 	} else {
-		writer.Write(append(content, '\n'))
+		writer.Write(append(jsonBuf.Bytes(), '\n'))
 	}
 }
 


### PR DESCRIPTION
改动后：
2021/01/06 10:14:49 {"@timestamp":"2021-01-06T10:14:49.221+08","level":"info","content":"hello: Stay hungry, stay foolish. > < &","trace":"mock-trace-id","span":"mock-span-id"}

改动前：
2021/01/06 10:22:29 {"@timestamp":"2021-01-06T10:22:29.382+08","level":"info","content":"hello: Stay hungry, stay foolish. \u003e \u003c \u0026","trace":"mock-trace-id","span":"mock-span-id"}
