### PR TITLE
feat: change logger to traceLogger for getting traceId when recovering

### DIFF
--- a/rest/internal/log.go
+++ b/rest/internal/log.go
@@ -49,11 +49,11 @@ func (lc *LogCollector) takeAll() []string {
 }
 
 func Error(r *http.Request, v ...interface{}) {
-	logx.ErrorCaller(1, format(r, v...))
+	logx.WithContext(r.Context()).Error(v)
 }
 
 func Errorf(r *http.Request, format string, v ...interface{}) {
-	logx.ErrorCaller(1, formatf(r, format, v...))
+	logx.WithContext(r.Context()).Errorf(format, v)
 }
 
 func Info(r *http.Request, v ...interface{}) {


### PR DESCRIPTION
goroutine panic后，RecoverHandler函数的log日志无traceid