### PR TITLE
fix server.start return nil points

### DIFF
--- a/core/proc/shutdown+polyfill.go
+++ b/core/proc/shutdown+polyfill.go
@@ -5,11 +5,11 @@ package proc
 import "time"
 
 func AddShutdownListener(fn func()) func() {
-	return nil
+	return fn
 }
 
 func AddWrapUpListener(fn func()) func() {
-	return nil
+	return fn
 }
 
 func SetTimeoutToForceQuit(duration time.Duration) {


### PR DESCRIPTION
When I bind two socket on one port or other start problem ; pannic is nil pointer
expect: return Error info


panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x854174]

goroutine 1 [running]:
github.com/tal-tech/go-zero/rest/internal.start(0x0, 0x0, 0xd05, 0x1444058, 0xc000096120, 0x987060, 0xa10640, 0xc00008a2d0)


problem:
	waitForCalled := proc.AddWrapUpListener(func() {
		server.Shutdown(context.Background())
	})
	defer waitForCalled()
func AddWrapUpListener/AddShutdownListener(fn fnc()) (func ())
        return nil

so that 


fix return nil --> return fn