### PR TITLE
fix cgroup bug

### DIFF
--- a/core/stat/internal/cgroup_linux.go
+++ b/core/stat/internal/cgroup_linux.go
@@ -92,11 +92,12 @@ func currentCgroup() (*cgroup, error) {
 			continue
 		}
 
-		cgroups[subsys] = path.Join(cgroupDir, subsys)
 		if strings.Contains(subsys, ",") {
 			for _, k := range strings.Split(subsys, ",") {
 				cgroups[k] = path.Join(cgroupDir, k)
 			}
+		} else {
+			cgroups[subsys] = path.Join(cgroupDir, subsys)
 		}
 	}
 


### PR DESCRIPTION
/proc/[pid]/cgroup中如果出现逗号","只保存逗号分割后的信息