### PR TITLE
fix the generate rpc error when path with whitespace

### DIFF
--- a/tools/goctl/rpc/execx/execx.go
+++ b/tools/goctl/rpc/execx/execx.go
@@ -19,7 +19,7 @@ func Run(arg string, dir string, in ...*bytes.Buffer) (string, error) {
 	case vars.OsMac, vars.OsLinux:
 		cmd = exec.Command("sh", "-c", arg)
 	case vars.OsWindows:
-		cmd = exec.Command("cmd.exe", "/c", arg)
+		cmd = exec.Command("powershell.exe", "/c", arg)
 	default:
 		return "", fmt.Errorf("unexpected os: %v", goos)
 	}

--- a/tools/goctl/rpc/generator/genpb.go
+++ b/tools/goctl/rpc/generator/genpb.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"bytes"
+	"github.com/tal-tech/go-zero/tools/goctl/util"
 	"path/filepath"
 	"strings"
 
@@ -16,14 +17,14 @@ func (g *defaultGenerator) GenPb(ctx DirContext, protoImportPath []string, proto
 	base := filepath.Dir(proto.Src)
 	cw.WriteString("protoc ")
 	for _, ip := range protoImportPath {
-		cw.WriteString(" -I=" + ip)
+		cw.WriteString(" -I=" + util.WrapPath(ip))
 	}
-	cw.WriteString(" -I=" + base)
+	cw.WriteString(" -I=" + util.WrapPath(base))
 	cw.WriteString(" " + proto.Name)
 	if strings.Contains(proto.GoPackage, "/") {
-		cw.WriteString(" --go_out=plugins=grpc:" + ctx.GetMain().Filename)
+		cw.WriteString(" --go_out=plugins=grpc:" + util.WrapPath(ctx.GetMain().Filename))
 	} else {
-		cw.WriteString(" --go_out=plugins=grpc:" + dir.Filename)
+		cw.WriteString(" --go_out=plugins=grpc:" + util.WrapPath(dir.Filename))
 	}
 	command := cw.String()
 	g.log.Debug(command)

--- a/tools/goctl/util/ctx/context.go
+++ b/tools/goctl/util/ctx/context.go
@@ -3,6 +3,7 @@ package ctx
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 
 	"github.com/tal-tech/go-zero/tools/goctl/rpc/execx"
 )
@@ -33,6 +34,7 @@ func Prepare(workDir string) (*ProjectContext, error) {
 	}
 
 	name := filepath.Base(workDir)
+	name = strings.ReplaceAll(name, " ", "_")
 	_, err = execx.Run("go mod init "+name, workDir)
 	if err != nil {
 		return nil, err

--- a/tools/goctl/util/path.go
+++ b/tools/goctl/util/path.go
@@ -109,7 +109,7 @@ func FindProjectPath(loc string) (string, bool) {
 
 func WrapPath(s string) string {
 	if s != "" && s[0] != '"' && s[0] != '\''  {
-		return `'` + s + `'`
+		return `"` + s + `"`
 	}
 	return s
 }

--- a/tools/goctl/util/path.go
+++ b/tools/goctl/util/path.go
@@ -106,3 +106,10 @@ func FindProjectPath(loc string) (string, bool) {
 
 	return "", false
 }
+
+func WrapPath(s string) string {
+	if s != "" && s[0] != '"' && s[0] != '\''  {
+		return `'` + s + `'`
+	}
+	return s
+}


### PR DESCRIPTION
1.修复在生成rpc时，由于路径存在空格导致生成失败：[issue 300](https://github.com/tal-tech/go-zero/issues/300)

2.调整在windows执行命令为powershell，而不是cmd.exe.

3.如果当前proto所在目录name也有空格，会自动将` ` 替换为 `_`，以便创建package name


```
powershell是微软在win7开始的版本提供的一个兼容性更高的shell工具，比cmd更方便。并且目前来说开发人员使用低于win7版本的应该几乎绝迹了。所以建议更换。
```
