### PR TITLE
zrpc client support block

### DIFF
--- a/zrpc/config.go
+++ b/zrpc/config.go
@@ -25,7 +25,7 @@ type (
 		Endpoints []string        `json:",optional=!Etcd"`
 		App       string          `json:",optional"`
 		Token     string          `json:",optional"`
-		Timeout   int64           `json:",optional"`
+		Timeout   int64           `json:",default=2000"`
 	}
 )
 

--- a/zrpc/internal/clientinterceptors/timeoutinterceptor.go
+++ b/zrpc/internal/clientinterceptors/timeoutinterceptor.go
@@ -8,15 +8,12 @@ import (
 	"google.golang.org/grpc"
 )
 
-const defaultTimeout = time.Second * 2
-
 func TimeoutInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
-	if timeout <= 0 {
-		timeout = defaultTimeout
-	}
-
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn,
 		invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if timeout == 0 {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
 		ctx, cancel := contextx.ShrinkDeadline(ctx, timeout)
 		defer cancel()
 		return invoker(ctx, method, req, reply, cc, opts...)


### PR DESCRIPTION
zrpc client支持不设置超时时间，默认超时时间通过配置文件中默认参数传入