### PR TITLE
modify the maximum content-length to 30MB

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -32,7 +32,7 @@ type (
 		KeyFile  string `json:",optional"`
 		Verbose  bool   `json:",optional"`
 		MaxConns int    `json:",default=10000"`
-		MaxBytes int64  `json:",default=1048576,range=[0:8388608]"`
+		MaxBytes int64  `json:",default=1048576,range=[0:31457280]"`
 		// milliseconds
 		Timeout      int64         `json:",default=3000"`
 		CpuThreshold int64         `json:",default=900,range=[0:1000]"`


### PR DESCRIPTION
之前http server（rest）支持的最大content-length限制为8MB，
如果，在一些场景下，比如上传一个小视频这类，会导致服务端拒绝
所以，这里适当的给最大值放大一些，提供更多的选择
