### PR TITLE
Simplify contextx.ShrinkDeadline

### DIFF
--- a/core/contextx/deadline.go
+++ b/core/contextx/deadline.go
@@ -8,12 +8,5 @@ import (
 // ShrinkDeadline returns a new Context with proper deadline base on the given ctx and timeout.
 // And returns a cancel function as well.
 func ShrinkDeadline(ctx context.Context, timeout time.Duration) (context.Context, func()) {
-	if deadline, ok := ctx.Deadline(); ok {
-		leftTime := time.Until(deadline)
-		if leftTime < timeout {
-			timeout = leftTime
-		}
-	}
-
-	return context.WithDeadline(ctx, time.Now().Add(timeout))
+	return context.WithTimeout(ctx, timeout)
 }


### PR DESCRIPTION
`contextx.ShrinkDeadline` 和标准库的 `context.WithTimeout` 是等价的。

标准库的 `context.WithDeadline` 已经做了 deadline 的计算（和 ShrinkDeadline 计算的原理相同），不会让派生的子 context 的 deadline 比父 context 晚。