### PR TITLE
语法错误

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ English | [简体中文](readme-cn.md)
 
 ## 0. what is go-zero
 
-go-zero is a web and rpc framework that with lots of engineering practices builtin. It’s born to ensure the stability of the busy services with resilience design, and has been serving sites with tens of millions users for years.
+go-zero is a web and rpc framework that incorporates various engineering practices. It’s born to ensure the stability of the busy services with resilience design, and has been serving sites with tens of millions users for years.
 
 go-zero contains simple API description syntax and code generation tool called `goctl`. You can generate Go, iOS, Android, Kotlin, Dart, TypeScript, JavaScript from .api files with `goctl`.
 


### PR DESCRIPTION
原句 *go-zero is a web and rpc framework that with lots of engineering practices builtin.* 有语法错误，**that** 后应跟一个从句，但后面明显是一个短语。

另一个可能的修改方式是： *go-zero is a web and rpc framework with lots of engineering practices built in.*

但感觉 *go-zero is a web and rpc framework that incorporates various engineering practices.* 与中文 *go-zero 是一个集成了各种工程实践的 web 和 rpc 框架。* 更符。