### PR TITLE
增加 bf 参数，支持公共配置文件合并

### DIFF
--- a/tools/goctl/api/gogen/genmain.go
+++ b/tools/goctl/api/gogen/genmain.go
@@ -20,12 +20,17 @@ import (
 	{{.importPackages}}
 )
 
+var baseConfigFile = flag.String("bf", "", "the base config file")
+
 var configFile = flag.String("f", "etc/{{.serviceName}}.yaml", "the config file")
 
 func main() {
 	flag.Parse()
 
 	var c config.Config
+	if *baseConfigFile != "" {
+		conf.MustLoad(*baseConfigFile, &c)
+	}
 	conf.MustLoad(*configFile, &c)
 
 	ctx := svc.NewServiceContext(c)

--- a/tools/goctl/rpc/generator/genmain.go
+++ b/tools/goctl/rpc/generator/genmain.go
@@ -25,12 +25,17 @@ import (
 	"google.golang.org/grpc"
 )
 
+var baseConfigFile = flag.String("bf", "", "the base config file")
+
 var configFile = flag.String("f", "etc/{{.serviceName}}.yaml", "the config file")
 
 func main() {
 	flag.Parse()
 
 	var c config.Config
+	if *baseConfigFile != "" {
+		conf.MustLoad(*baseConfigFile, &c)
+	}
 	conf.MustLoad(*configFile, &c)
 	ctx := svc.NewServiceContext(c)
 	srv := server.New{{.serviceNew}}Server(ctx)


### PR DESCRIPTION
公共配置文件和应用配置文件有大量需求，通过指定 bf 参数，进行配置合并