### PR TITLE
Fix #624 support secure RPCclient

### DIFF
--- a/zrpc/client.go
+++ b/zrpc/client.go
@@ -17,6 +17,8 @@ var (
 	WithTimeout = internal.WithTimeout
 	// WithUnaryClientInterceptor is an alias of internal.WithUnaryClientInterceptor.
 	WithUnaryClientInterceptor = internal.WithUnaryClientInterceptor
+	// WithInsecure is an alias of internal.WithInsecure.
+	WithInsecure = internal.WithInsecure
 )
 
 type (
@@ -54,6 +56,9 @@ func NewClient(c RpcClientConf, options ...ClientOption) (Client, error) {
 		opts = append(opts, WithTimeout(time.Duration(c.Timeout)*time.Millisecond))
 	}
 	opts = append(opts, options...)
+	if !c.SecureOpt {
+		opts = append(opts, WithInsecure())
+	}
 
 	var client Client
 	var err error

--- a/zrpc/config.go
+++ b/zrpc/config.go
@@ -27,6 +27,7 @@ type (
 		App       string          `json:",optional"`
 		Token     string          `json:",optional"`
 		Timeout   int64           `json:",default=2000"`
+		SecureOpt bool            `json:",default=0"`
 	}
 )
 

--- a/zrpc/internal/client.go
+++ b/zrpc/internal/client.go
@@ -64,7 +64,6 @@ func (c *client) buildDialOptions(opts ...ClientOption) []grpc.DialOption {
 	}
 
 	options := []grpc.DialOption{
-		grpc.WithInsecure(),
 		grpc.WithBlock(),
 		WithUnaryClientInterceptors(
 			clientinterceptors.TracingInterceptor,
@@ -104,6 +103,13 @@ func (c *client) dial(server string, opts ...ClientOption) error {
 func WithDialOption(opt grpc.DialOption) ClientOption {
 	return func(options *ClientOptions) {
 		options.DialOptions = append(options.DialOptions, opt)
+	}
+}
+
+// WithInsecure returns a func to customize a ClientOptions with secure option.
+func WithInsecure() ClientOption {
+	return func(options *ClientOptions) {
+		options.DialOptions = append(options.DialOptions, grpc.WithInsecure())
 	}
 }
 


### PR DESCRIPTION
fix#624 

> zrpc client 连接服务端 dialoptions 直接写死 withInsecure 了，是不是可以考虑支持一下证书设置

可通过RpcClientConf添加Secure

RpcClientConf struct {
		Etcd      discov.EtcdConf `json:",optional"`
		Endpoints []string        `json:",optional=!Etcd"`
		App       string          `json:",optional"`
		Token     string          `json:",optional"`
		Timeout   int64           `json:",default=2000"`
                //0==withInsecure ;
		SecureOpt bool            `json:",default=0"`
}


