### PR TITLE
fix the overflow of expire time

### DIFF
--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -24,7 +24,7 @@ const (
 
 	slowThreshold = time.Millisecond * 100
 
-	// Seconds of ten year
+	// Seconds of ten years
 	maxExpireTime = 10 * 365 * 24 * 3600
 )
 

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -23,10 +23,17 @@ const (
 	readWriteTimeout     = 2 * time.Second
 
 	slowThreshold = time.Millisecond * 100
+
+	//seconds of ten year
+	maxExpireTime = 10 * 365 * 24 * 3600
 )
 
-// ErrNilNode is an error that indicates a nil redis node.
-var ErrNilNode = errors.New("nil redis node")
+var (
+	// ErrNilNode is an error that indicates a nil redis node.
+	ErrNilNode = errors.New("nil redis node")
+	// ErrTimeTooBig is an error that indicates the expireTime is too big.
+	ErrExpireTimeTooBig = errors.New("expireTime too big")
+)
 
 type (
 	// Option defines the method to customize a Redis.
@@ -304,6 +311,10 @@ func (s *Redis) Exists(key string) (val bool, err error) {
 
 // Expire is the implementation of redis expire command.
 func (s *Redis) Expire(key string, seconds int) error {
+	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
+	if seconds > maxExpireTime {
+		return ErrExpireTimeTooBig
+	}
 	return s.brk.DoWithAcceptable(func() error {
 		conn, err := getRedis(s)
 		if err != nil {

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -31,11 +31,10 @@ const (
 var (
 	// ErrNilNode is an error that indicates a nil redis node.
 	ErrNilNode = errors.New("nil redis node")
-	/*
-		ErrTimeTooBig is an error that indicates the expireTime is too big.
-		If the expireTime overflows the max value of time.duration, approximately 290 years, the expireTime may become negative.
-		The negative expireTime will cause the k/v in redis to be deleted.
-	*/
+
+	//ErrTimeTooBig is an error that indicates the expireTime is too big.
+	//If the expireTime overflows the max value of time.duration, approximately 290 years, the expireTime may become negative.
+	//The negative expireTime will cause the k/v in redis to be deleted.
 	ErrExpireTimeTooBig = errors.New("expireTime too big")
 )
 

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -33,7 +33,7 @@ var (
 	ErrNilNode = errors.New("nil redis node")
 	/*
 		ErrTimeTooBig is an error that indicates the expireTime is too big.
-		If the expireTime overflows max value of time.duration, approximately 290 years, the expireTime may become negative.
+		If the expireTime overflows the max value of time.duration, approximately 290 years, the expireTime may become negative.
 		The negative expireTime will cause the k/v in redis to be deleted.
 	*/
 	ErrExpireTimeTooBig = errors.New("expireTime too big")

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -1125,6 +1125,10 @@ func (s *Redis) Setnx(key, value string) (val bool, err error) {
 
 // SetnxEx is the implementation of redis setnx command with expire.
 func (s *Redis) SetnxEx(key, value string, seconds int) (val bool, err error) {
+	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
+	if seconds > maxExpireTime {
+		return false,ErrExpireTimeTooBig
+	}
 	err = s.brk.DoWithAcceptable(func() error {
 		conn, err := getRedis(s)
 		if err != nil {

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -24,14 +24,18 @@ const (
 
 	slowThreshold = time.Millisecond * 100
 
-	//seconds of ten year
+	// Seconds of ten year。
 	maxExpireTime = 10 * 365 * 24 * 3600
 )
 
 var (
 	// ErrNilNode is an error that indicates a nil redis node.
 	ErrNilNode = errors.New("nil redis node")
-	// ErrTimeTooBig is an error that indicates the expireTime is too big.
+	/*
+		ErrTimeTooBig is an error that indicates the expireTime is too big.
+		If the expireTime overflow time.duration, above 290 year, the expireTime may become negative.
+		The negative expireTime will cause the k/v in redis to be deleted.
+	*/
 	ErrExpireTimeTooBig = errors.New("expireTime too big")
 )
 
@@ -311,7 +315,6 @@ func (s *Redis) Exists(key string) (val bool, err error) {
 
 // Expire is the implementation of redis expire command.
 func (s *Redis) Expire(key string, seconds int) error {
-	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
 	if seconds > maxExpireTime {
 		return ErrExpireTimeTooBig
 	}
@@ -1098,7 +1101,6 @@ func (s *Redis) Set(key string, value string) error {
 
 // Setex is the implementation of redis setex command.
 func (s *Redis) Setex(key, value string, seconds int) error {
-	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
 	if seconds > maxExpireTime {
 		return ErrExpireTimeTooBig
 	}
@@ -1129,7 +1131,6 @@ func (s *Redis) Setnx(key, value string) (val bool, err error) {
 
 // SetnxEx is the implementation of redis setnx command with expire.
 func (s *Redis) SetnxEx(key, value string, seconds int) (val bool, err error) {
-	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
 	if seconds > maxExpireTime {
 		return false, ErrExpireTimeTooBig
 	}

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -24,7 +24,7 @@ const (
 
 	slowThreshold = time.Millisecond * 100
 
-	// Seconds of ten year。
+	// Seconds of ten year
 	maxExpireTime = 10 * 365 * 24 * 3600
 )
 
@@ -33,7 +33,7 @@ var (
 	ErrNilNode = errors.New("nil redis node")
 	/*
 		ErrTimeTooBig is an error that indicates the expireTime is too big.
-		If the expireTime overflow time.duration, above 290 year, the expireTime may become negative.
+		If the expireTime overflows max value of time.duration, approximately 290 years, the expireTime may become negative.
 		The negative expireTime will cause the k/v in redis to be deleted.
 	*/
 	ErrExpireTimeTooBig = errors.New("expireTime too big")

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -1098,6 +1098,10 @@ func (s *Redis) Set(key string, value string) error {
 
 // Setex is the implementation of redis setex command.
 func (s *Redis) Setex(key, value string, seconds int) error {
+	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
+	if seconds > maxExpireTime {
+		return ErrExpireTimeTooBig
+	}
 	return s.brk.DoWithAcceptable(func() error {
 		conn, err := getRedis(s)
 		if err != nil {
@@ -1127,7 +1131,7 @@ func (s *Redis) Setnx(key, value string) (val bool, err error) {
 func (s *Redis) SetnxEx(key, value string, seconds int) (val bool, err error) {
 	//If the expireTime overflow time.duration, above 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.
 	if seconds > maxExpireTime {
-		return false,ErrExpireTimeTooBig
+		return false, ErrExpireTimeTooBig
 	}
 	err = s.brk.DoWithAcceptable(func() error {
 		conn, err := getRedis(s)


### PR DESCRIPTION
The pull request fix the bug that expireTime overflow time.duration.
Usually the expireTime for redis key should less than 10 years. But sometimes people write wrong code so that the expireTime is too big. The go-zero should find and throw the error as soon as possible. If the expireTime overflow the max value of time.duration, 290 year, the expireTime may become negative. The negative expireTime will cause the k/v in redis to be deleted.