### PR TITLE
format call dir with -style flag

### DIFF
--- a/tools/goctl/rpc/generator/gen.go
+++ b/tools/goctl/rpc/generator/gen.go
@@ -63,7 +63,7 @@ func (g *RPCGenerator) Generate(src, target string, protoImportPath []string) er
 		return err
 	}
 
-	dirCtx, err := mkdir(projectCtx, proto)
+	dirCtx, err := mkdir(projectCtx, proto, g.cfg)
 	if err != nil {
 		return err
 	}

--- a/tools/goctl/rpc/generator/mkdir.go
+++ b/tools/goctl/rpc/generator/mkdir.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	conf "github.com/tal-tech/go-zero/tools/goctl/config"
+	"github.com/tal-tech/go-zero/tools/goctl/util/format"
 	"path/filepath"
 	"strings"
 
@@ -50,7 +52,7 @@ type (
 	}
 )
 
-func mkdir(ctx *ctx.ProjectContext, proto parser.Proto) (DirContext, error) {
+func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, cfg *conf.Config) (DirContext, error) {
 	inner := make(map[string]Dir)
 	etcDir := filepath.Join(ctx.WorkDir, "etc")
 	internalDir := filepath.Join(ctx.WorkDir, "internal")
@@ -61,7 +63,11 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto) (DirContext, error) {
 	pbDir := filepath.Join(ctx.WorkDir, proto.GoPackage)
 	callDir := filepath.Join(ctx.WorkDir, strings.ToLower(stringx.From(proto.Service.Name).ToCamel()))
 	if strings.ToLower(proto.Service.Name) == strings.ToLower(proto.GoPackage) {
-		callDir = filepath.Join(ctx.WorkDir, strings.ToLower(stringx.From(proto.Service.Name+"_client").ToCamel()))
+		tmpCallDir, err := format.FileNamingFormat(cfg.NamingFormat, proto.Service.Name+"_client")
+		if err != nil {
+			tmpCallDir = strings.ToLower(stringx.From(proto.Service.Name+"_client").ToCamel())
+		}
+		callDir = filepath.Join(ctx.WorkDir, tmpCallDir)
 	}
 
 	inner[wd] = Dir{


### PR DESCRIPTION
统一下代码生成的文件夹风格。

```go
if strings.ToLower(proto.Service.Name) == strings.ToLower(proto.GoPackage) {
```
的 case 也能保持 style 一致。