### PR TITLE
replace subset selection algorithm

### DIFF
--- a/zrpc/internal/resolver/subset.go
+++ b/zrpc/internal/resolver/subset.go
@@ -1,14 +1,29 @@
 package resolver
 
-import "math/rand"
+import (
+	"github.com/tal-tech/go-zero/core/hash"
+	"github.com/tal-tech/go-zero/core/sysx"
+	"math/rand"
+)
 
 func subset(set []string, sub int) []string {
-	rand.Shuffle(len(set), func(i, j int) {
-		set[i], set[j] = set[j], set[i]
-	})
 	if len(set) <= sub {
+		rand.Shuffle(len(set), func(i, j int) {
+			set[i], set[j] = set[j], set[i]
+		})
 		return set
 	}
 
-	return set[:sub]
+	// group clients into rounds, each round uses the same shuffled list
+	count := uint64(len(set) / sub)
+	clientID := hash.Hash([]byte(sysx.Hostname()))
+	round := clientID / count
+
+	r := rand.New(rand.NewSource(int64(round)))
+	r.Shuffle(len(set), func(i, j int) {
+		set[i], set[j] = set[j], set[i]
+	})
+
+	start := (clientID % count) * uint64(sub)
+	return set[start : start+uint64(sub)]
 }


### PR DESCRIPTION
- 原有随机算法都使用同一个[随机种子](https://github.com/golang/go/blob/79bda650410c8617f0ae20dc552c6d5b8f8dcfc8/src/math/rand/rand.go#L295)，在后端列表不变的情况下，同类客户端任务选择的重排列表子集是一样的。随机效果不好，负载也可能不均衡
- 使用google的确定性算法替换随机算法，确定性算法根据client_id划分轮数（round），不同round使用不同的的随机种子，产生的重排列表也不一样，相同round使用相同的重排列表，但是每一个后端只会分配给唯一一个客户端，所以整个连接负载会均匀地分布
- 参考资料
   - https://sre.google/sre-book/load-balancing-datacenter/
   - https://xargin.com/limiting-conn-wih-subset/