### PR TITLE
修复 WithNotFoundHandler 和 WithNotAllowedHandler 不能共存的问题

### DIFF
--- a/rest/router/patrouter.go
+++ b/rest/router/patrouter.go
@@ -22,7 +22,7 @@ var (
 	// ErrInvalidPath is an error that indicates path is not start with /.
 	ErrInvalidPath = errors.New("path must begin with '/'")
 	// instantiate only once
-	pat *patRouter
+	defaultPat httpx.Router
 )
 
 type patRouter struct {
@@ -33,12 +33,16 @@ type patRouter struct {
 
 // NewRouter returns a httpx.Router.
 func NewRouter() httpx.Router {
-	if pat == nil {
-		pat = &patRouter{
-			trees: make(map[string]*search.Tree),
-		}
+	return &patRouter{
+		trees: make(map[string]*search.Tree),
 	}
-	return pat
+}
+
+func GetDefaultRouter() httpx.Router {
+	if defaultPat == nil {
+		defaultPat = NewRouter()
+	}
+	return defaultPat
 }
 
 func (pr *patRouter) Handle(method, reqPath string, handler http.Handler) error {

--- a/rest/router/patrouter.go
+++ b/rest/router/patrouter.go
@@ -21,6 +21,8 @@ var (
 	ErrInvalidMethod = errors.New("not a valid http method")
 	// ErrInvalidPath is an error that indicates path is not start with /.
 	ErrInvalidPath = errors.New("path must begin with '/'")
+	// instantiate only once
+	pat *patRouter
 )
 
 type patRouter struct {
@@ -31,9 +33,12 @@ type patRouter struct {
 
 // NewRouter returns a httpx.Router.
 func NewRouter() httpx.Router {
-	return &patRouter{
-		trees: make(map[string]*search.Tree),
+	if pat == nil {
+		pat = &patRouter{
+			trees: make(map[string]*search.Tree),
+		}
 	}
+	return pat
 }
 
 func (pr *patRouter) Handle(method, reqPath string, handler http.Handler) error {

--- a/rest/router/patrouter_test.go
+++ b/rest/router/patrouter_test.go
@@ -84,6 +84,32 @@ func TestPatRouterNotAllowed(t *testing.T) {
 	assert.True(t, notAllowed)
 }
 
+func TestPatRouterNotFoundAndNotAllowed(t *testing.T) {
+	var notFound, notAllowed bool
+	router := GetDefaultRouter()
+	router.SetNotFoundHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notFound = true
+	}))
+	router.SetNotAllowedHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notAllowed = true
+	}))
+	err := router.Handle(http.MethodGet, "/a/b",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	assert.Nil(t, err)
+
+	// not found
+	r, _ := http.NewRequest(http.MethodGet, "/a/c", nil)
+	w := new(mockedResponseWriter)
+	router.ServeHTTP(w, r)
+	assert.True(t, notFound)
+
+	// not allowed
+	r, _ = http.NewRequest(http.MethodPost, "/a/b", nil)
+	w = new(mockedResponseWriter)
+	router.ServeHTTP(w, r)
+	assert.True(t, notAllowed)
+}
+
 func TestPatRouter(t *testing.T) {
 	tests := []struct {
 		method string

--- a/rest/server.go
+++ b/rest/server.go
@@ -148,14 +148,14 @@ func WithMiddleware(middleware Middleware, rs ...Route) []Route {
 
 // WithNotFoundHandler returns a RunOption with not found handler set to given handler.
 func WithNotFoundHandler(handler http.Handler) RunOption {
-	rt := router.NewRouter()
+	rt := router.GetDefaultRouter()
 	rt.SetNotFoundHandler(handler)
 	return WithRouter(rt)
 }
 
 // WithNotAllowedHandler returns a RunOption with not allowed handler set to given handler.
 func WithNotAllowedHandler(handler http.Handler) RunOption {
-	rt := router.NewRouter()
+	rt := router.GetDefaultRouter()
 	rt.SetNotAllowedHandler(handler)
 	return WithRouter(rt)
 }


### PR DESCRIPTION
如果我定义了一个路由 `GET /foo/bar`
如果我访问 `POST /foo/bar` 按理来说,这个情况属于 `notAllowed`
如果我访问 `GET /foo/bars` 按理来说,这个情况属于 `notFound`
所以我访问时路由时,既可能出现 `notAllowed`, 也有可能会出现 `notFound`, 所以这两种情况可以同时存在
但是在代码中,两个方法都新建了 `patRouter` ,导致只会有一个 `patRouter` 生效,不合理
```go
func WithNotFoundHandler(handler http.Handler) RunOption {
	rt := router.NewRouter() // 新建
	rt.SetNotFoundHandler(handler)
	return WithRouter(rt)
}

func WithNotAllowedHandler(handler http.Handler) RunOption {
	rt := router.NewRouter() // 新建
	rt.SetNotAllowedHandler(handler)
	return WithRouter(rt)
}
```
