### PR TITLE
replace cache key with colon

### DIFF
--- a/tools/goctl/model/mongo/template/template.go
+++ b/tools/goctl/model/mongo/template/template.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tal-tech/go-zero/core/stores/mongoc"
 )
 
-{{if .Cache}}var prefix{{.Type}}CacheKey = "cache#{{.Type}}#"{{end}}
+{{if .Cache}}var prefix{{.Type}}CacheKey = "cache:{{.Type}}:"{{end}}
 
 type {{.Type}}Model interface{
 	Insert(ctx context.Context,data *{{.Type}}) error

--- a/tools/goctl/model/sql/gen/keys.go
+++ b/tools/goctl/model/sql/gen/keys.go
@@ -13,9 +13,9 @@ import (
 type Key struct {
 	// VarLeft describes the variable of cache key expression which likes cacheUserIdPrefix
 	VarLeft string
-	// VarRight describes the value of cache key expression which likes "cache#user#id#"
+	// VarRight describes the value of cache key expression which likes "cache:user:id:"
 	VarRight string
-	// VarExpression describes the cache key expression which likes cacheUserIdPrefix = "cache#user#id#"
+	// VarExpression describes the cache key expression which likes cacheUserIdPrefix = "cache:user:id:"
 	VarExpression string
 	// KeyLeft describes the variable of key definition expression which likes userKey
 	KeyLeft string
@@ -76,12 +76,12 @@ func genCacheKey(table stringx.String, in []*parser.Field) Key {
 	keyLeftJoin = append(keyLeftJoin, "key")
 
 	varLeft = varLeftJoin.Camel().With("").Untitle()
-	varRight = fmt.Sprintf(`"%s"`, varRightJon.Camel().Untitle().With("#").Source()+"#")
+	varRight = fmt.Sprintf(`"%s"`, varRightJon.Camel().Untitle().With(":").Source()+":")
 	varExpression = fmt.Sprintf(`%s = %s`, varLeft, varRight)
 
 	keyLeft = keyLeftJoin.Camel().With("").Untitle()
-	keyRight = fmt.Sprintf(`fmt.Sprintf("%s%s", %s, %s)`, "%s", keyRightArgJoin.With("").Source(), varLeft, keyRightJoin.With(", ").Source())
-	dataKeyRight = fmt.Sprintf(`fmt.Sprintf("%s%s", %s, %s)`, "%s", keyRightArgJoin.With("").Source(), varLeft, dataRightJoin.With(", ").Source())
+	keyRight = fmt.Sprintf(`fmt.Sprintf("%s%s", %s, %s)`, "%s", keyRightArgJoin.With(":").Source(), varLeft, keyRightJoin.With(", ").Source())
+	dataKeyRight = fmt.Sprintf(`fmt.Sprintf("%s%s", %s, %s)`, "%s", keyRightArgJoin.With(":").Source(), varLeft, dataRightJoin.With(", ").Source())
 	keyExpression = fmt.Sprintf("%s := %s", keyLeft, keyRight)
 	dataKeyExpression = fmt.Sprintf("%s := %s", keyLeft, dataKeyRight)
 

--- a/tools/goctl/model/sql/gen/keys_test.go
+++ b/tools/goctl/model/sql/gen/keys_test.go
@@ -78,8 +78,8 @@ func TestGenCacheKeys(t *testing.T) {
 		assert.Equal(t, true, func() bool {
 			return cacheKeyEqual(primariCacheKey, Key{
 				VarLeft:           "cacheUserIdPrefix",
-				VarRight:          `"cache#user#id#"`,
-				VarExpression:     `cacheUserIdPrefix = "cache#user#id#"`,
+				VarRight:          `"cache:user:id:"`,
+				VarExpression:     `cacheUserIdPrefix = "cache:user:id:"`,
 				KeyLeft:           "userIdKey",
 				KeyRight:          `fmt.Sprintf("%s%v", cacheUserIdPrefix, id)`,
 				DataKeyRight:      `fmt.Sprintf("%s%v", cacheUserIdPrefix, data.Id)`,
@@ -95,19 +95,19 @@ func TestGenCacheKeys(t *testing.T) {
 			expected := []Key{
 				{
 					VarLeft:           "cacheUserClassNamePrefix",
-					VarRight:          `"cache#user#class#name#"`,
-					VarExpression:     `cacheUserClassNamePrefix = "cache#user#class#name#"`,
+					VarRight:          `"cache:user:class:name:"`,
+					VarExpression:     `cacheUserClassNamePrefix = "cache:user:class:name:"`,
 					KeyLeft:           "userClassNameKey",
-					KeyRight:          `fmt.Sprintf("%s%v%v", cacheUserClassNamePrefix, class, name)`,
-					DataKeyRight:      `fmt.Sprintf("%s%v%v", cacheUserClassNamePrefix, data.Class, data.Name)`,
-					KeyExpression:     `userClassNameKey := fmt.Sprintf("%s%v%v", cacheUserClassNamePrefix, class, name)`,
-					DataKeyExpression: `userClassNameKey := fmt.Sprintf("%s%v%v", cacheUserClassNamePrefix, data.Class, data.Name)`,
+					KeyRight:          `fmt.Sprintf("%s%v:%v", cacheUserClassNamePrefix, class, name)`,
+					DataKeyRight:      `fmt.Sprintf("%s%v:%v", cacheUserClassNamePrefix, data.Class, data.Name)`,
+					KeyExpression:     `userClassNameKey := fmt.Sprintf("%s%v:%v", cacheUserClassNamePrefix, class, name)`,
+					DataKeyExpression: `userClassNameKey := fmt.Sprintf("%s%v:%v", cacheUserClassNamePrefix, data.Class, data.Name)`,
 					FieldNameJoin:     []string{"class", "name"},
 				},
 				{
 					VarLeft:           "cacheUserMobilePrefix",
-					VarRight:          `"cache#user#mobile#"`,
-					VarExpression:     `cacheUserMobilePrefix = "cache#user#mobile#"`,
+					VarRight:          `"cache:user:mobile:"`,
+					VarExpression:     `cacheUserMobilePrefix = "cache:user:mobile:"`,
 					KeyLeft:           "userMobileKey",
 					KeyRight:          `fmt.Sprintf("%s%v", cacheUserMobilePrefix, mobile)`,
 					DataKeyRight:      `fmt.Sprintf("%s%v", cacheUserMobilePrefix, data.Mobile)`,


### PR DESCRIPTION
## Features
* replace cache key with colon

## Notes
if you have plan to use the latest cache templates of model, which changed the cache key splitter from `#` to `:`,
you must execute command `goctl template` to update the model templates, for more information of update template, please see `goctl template -h`
