### PR TITLE
修复不支持多维度切片以及不支持基本类型指针切片

### DIFF
--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -3,6 +3,7 @@ package mapping
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -2479,4 +2480,41 @@ func BenchmarkUnmarshal(b *testing.B) {
 		var an anonymous
 		UnmarshalKey(data, &an)
 	}
+}
+
+func TestUnmarshalJsonReaderMultiArray(t *testing.T) {
+	payload := `{"a": "133", "b": [["add", "cccd"], ["eeee"]]}`
+	var res struct {
+		A string     `json:"a"`
+		B [][]string `json:"b"`
+	}
+	reader := strings.NewReader(payload)
+	err := UnmarshalJsonReader(reader, &res)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(res.B))
+}
+
+func TestUnmarshalJsonReaderPtrMultiArray(t *testing.T) {
+	payload := `{"a": "133", "b": [["add", "cccd"], ["eeee"]]}`
+	var res struct {
+		A string      `json:"a"`
+		B [][]*string `json:"b"`
+	}
+	reader := strings.NewReader(payload)
+	err := UnmarshalJsonReader(reader, &res)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(res.B))
+	assert.Equal(t, 2, len(res.B[0]))
+}
+
+func TestUnmarshalJsonReaderPtrArray(t *testing.T) {
+	payload := `{"a": "133", "b": ["add", "cccd", "eeee"]}`
+	var res struct {
+		A string    `json:"a"`
+		B []*string `json:"b"`
+	}
+	reader := strings.NewReader(payload)
+	err := UnmarshalJsonReader(reader, &res)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(res.B))
 }


### PR DESCRIPTION
使用多维切片的时候报错：panic: reflect.Set: value of type []interface {} is not assignable to type []string
对应测试用例为
`func TestUnmarshalJsonReaderMultiArray(t *testing.T) {
	payload := `{"a": "133", "b": [["add", "cccd"], ["eeee"]]}`
	var res struct {
		A string     `json:"a"`
		B [][]string `json:"b"`
	}
	reader := strings.NewReader(payload)
	err := UnmarshalJsonReader(reader, &res)
	assert.Nil(t, err)
	assert.Equal(t, 2, len(res.B))
}`

使用基础类型指针切片的时候对应的值未被反序列化
对应测试用例为：
func TestUnmarshalJsonReaderPtrArray(t *testing.T) {
	payload := `{"a": "133", "b": ["add", "cccd", "eeee"]}`
	var res struct {
		A string    `json:"a"`
		B []*string `json:"b"`
	}
	reader := strings.NewReader(payload)
	err := UnmarshalJsonReader(reader, &res)
	assert.Nil(t, err)
	assert.Equal(t, 3, len(res.B))
}

结果：
![image](https://user-images.githubusercontent.com/24541857/122880489-a00bf900-d36c-11eb-8dfe-8e9daf9f4d6c.png)

