### PR TITLE
Update 优化NewSharedCalls

### DIFF
--- a/core/syncx/sharedcalls.go
+++ b/core/syncx/sharedcalls.go
@@ -15,67 +15,65 @@ type (
 	}
 
 	call struct {
-		wg  sync.WaitGroup
-		val interface{}
-		err error
+		wg       sync.WaitGroup
+		consumer sync.WaitGroup
+		val      interface{}
+		err      error
 	}
 
 	sharedGroup struct {
-		calls map[string]*call
-		lock  sync.Mutex
+		calls *sync.Map
+		pools *sync.Pool //
 	}
 )
 
 // NewSharedCalls returns a SharedCalls.
 func NewSharedCalls() SharedCalls {
+	newFun := func() interface{} {
+		return &call{}
+	}
 	return &sharedGroup{
-		calls: make(map[string]*call),
+		calls: &sync.Map{},
+		pools: &sync.Pool{New: newFun},
 	}
 }
 
 func (g *sharedGroup) Do(key string, fn func() (interface{}, error)) (interface{}, error) {
-	c, done := g.createCall(key)
-	if done {
-		return c.val, c.err
-	}
-
-	g.makeCall(c, key, fn)
-	return c.val, c.err
+	val, _, err := g.do(key, fn)
+	return val, err
 }
 
 func (g *sharedGroup) DoEx(key string, fn func() (interface{}, error)) (val interface{}, fresh bool, err error) {
-	c, done := g.createCall(key)
-	if done {
-		return c.val, false, c.err
-	}
-
-	g.makeCall(c, key, fn)
-	return c.val, true, c.err
+	return g.do(key, fn)
 }
+func (g *sharedGroup) do(key string, fn func() (interface{}, error)) (val interface{}, fresh bool, err error) {
+	// get a *call
+	cc := g.pools.Get()
+	if v, ok := g.calls.LoadOrStore(key, cc); ok {
+		// restore a *call
+		g.pools.Put(cc)
 
-func (g *sharedGroup) createCall(key string) (c *call, done bool) {
-	g.lock.Lock()
-	if c, ok := g.calls[key]; ok {
-		g.lock.Unlock()
+		c := v.(*call)
 		c.wg.Wait()
-		return c, true
+
+		c.consumer.Add(1)
+		val = c.val
+		err = c.err
+		c.consumer.Done()
+		return val, false, err
+	} else {
+		c := v.(*call)
+		defer func() {
+			c.wg.Done()
+			g.calls.Delete(key)
+
+			// wait for the consumption of other goroutines to complete,restore a *call
+			c.consumer.Wait()
+			g.pools.Put(c)
+
+		}()
+		c.wg.Add(1)
+		c.val, c.err = fn()
+		return c.val, true, c.err
 	}
-
-	c = new(call)
-	c.wg.Add(1)
-	g.calls[key] = c
-	g.lock.Unlock()
-
-	return c, false
-}
-
-func (g *sharedGroup) makeCall(c *call, key string, fn func() (interface{}, error)) {
-	defer func() {
-		g.lock.Lock()
-		delete(g.calls, key)
-		g.lock.Unlock()
-		c.wg.Done()
-	}()
-
-	c.val, c.err = fn()
 }


### PR DESCRIPTION
- 使用`sync.Map`提升并发性能,此处读多写少
- 使用`sync.Pool`复用`*call`,减少GC和`*call`的创建