### PR TITLE
redis.go，type StringCmd = red.StringCmd

### DIFF
--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -1282,6 +1282,41 @@ func (s *Redis) Sdiffstore(destination string, keys ...string) (val int, err err
 	return
 }
 
+// Sinter is the implementation of redis sinter command.
+func (s *Redis) Sinter(keys ...string) (val []string, err error) {
+	err = s.brk.DoWithAcceptable(func() error {
+		conn, err := getRedis(s)
+		if err != nil {
+			return err
+		}
+
+		val, err = conn.SInter(keys...).Result()
+		return err
+	}, acceptable)
+
+	return
+}
+
+// Sinterstore is the implementation of redis sinterstore command.
+func (s *Redis) Sinterstore(destination string, keys ...string) (val int, err error) {
+	err = s.brk.DoWithAcceptable(func() error {
+		conn, err := getRedis(s)
+		if err != nil {
+			return err
+		}
+
+		v, err := conn.SInterStore(destination, keys...).Result()
+		if err != nil {
+			return err
+		}
+
+		val = int(v)
+		return nil
+	}, acceptable)
+
+	return
+}
+
 // Ttl is the implementation of redis ttl command.
 func (s *Redis) Ttl(key string) (val int, err error) {
 	err = s.brk.DoWithAcceptable(func() error {

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -71,6 +71,8 @@ type (
 	IntCmd = red.IntCmd
 	// FloatCmd is an alias of redis.FloatCmd.
 	FloatCmd = red.FloatCmd
+	// StringCmd is an alias of redis.StringCmd.
+	StringCmd = red.StringCmd
 )
 
 // New returns a Redis with given options.

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -638,6 +638,16 @@ func TestRedis_Set(t *testing.T) {
 		num, err = client.Sdiffstore("key4", "key1", "key2")
 		assert.Nil(t, err)
 		assert.Equal(t, 1, num)
+		_, err = New(client.Addr, badType()).Sinter("key1", "key2")
+		assert.NotNil(t, err)
+		vals, err = client.Sinter("key1", "key2")
+		assert.Nil(t, err)
+		assert.EqualValues(t, []string{"2", "3", "4"}, vals)
+		_, err = New(client.Addr, badType()).Sinterstore("key4", "key1", "key2")
+		assert.NotNil(t, err)
+		num, err = client.Sinterstore("key4", "key1", "key2")
+		assert.Nil(t, err)
+		assert.Equal(t, 3, num)
 	})
 }
 

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -642,11 +642,7 @@ func TestRedis_Set(t *testing.T) {
 		assert.NotNil(t, err)
 		vals, err = client.Sinter("key1", "key2")
 		assert.Nil(t, err)
-<<<<<<< HEAD
-		assert.EqualValues(t, []string{"2", "3", "4"}, vals)
-=======
 		assert.ElementsMatch(t, []string{"2", "3", "4"}, vals)
->>>>>>> master
 		_, err = New(client.Addr, badType()).Sinterstore("key4", "key1", "key2")
 		assert.NotNil(t, err)
 		num, err = client.Sinterstore("key4", "key1", "key2")


### PR DESCRIPTION
当我在集群模式下，不能使用mget操作，用redis.Pipelined实现多个get操作来模拟mget操作，需要StringCmd
// StringCmd is an alias of redis.StringCmd.
StringCmd = red.StringCmd
