### PR TITLE
fix context missing

### DIFF
--- a/tools/goctl/rpc/generator/genserver.go
+++ b/tools/goctl/rpc/generator/genserver.go
@@ -73,11 +73,20 @@ func (g *DefaultGenerator) GenServer(ctx DirContext, proto parser.Proto, cfg *co
 		return err
 	}
 
+	notStream := false
+	for _, rpc := range service.RPC {
+		if !rpc.StreamsRequest && !rpc.StreamsReturns {
+			notStream = true
+			break
+		}
+	}
+
 	err = util.With("server").GoFmt(true).Parse(text).SaveTo(map[string]interface{}{
-		"head":    head,
-		"server":  stringx.From(service.Name).ToCamel(),
-		"imports": strings.Join(imports.KeysStr(), util.NL),
-		"funcs":   strings.Join(funcList, util.NL),
+		"head":      head,
+		"server":    stringx.From(service.Name).ToCamel(),
+		"imports":   strings.Join(imports.KeysStr(), util.NL),
+		"funcs":     strings.Join(funcList, util.NL),
+		"notStream": notStream,
 	}, serverFile, true)
 	return err
 }


### PR DESCRIPTION
生成的server方法里少了context，因为notStream这个变量只定义在了genFunctions中

GenServer中使用的serverTemplate没有notStream这个变量，导致生成的server的import里永远少了context