### PR TITLE
optimize grpc generation env check

### DIFF
--- a/tools/goctl/model/sql/model/postgresqlmodel.go
+++ b/tools/goctl/model/sql/model/postgresqlmodel.go
@@ -8,12 +8,13 @@ import (
 )
 
 var p2m = map[string]string{
-	"int8":    "bigint",
-	"numeric": "bigint",
-	"float8":  "double",
-	"float4":  "float",
-	"int2":    "smallint",
-	"int4":    "integer",
+	"int8":        "bigint",
+	"numeric":     "bigint",
+	"float8":      "double",
+	"float4":      "float",
+	"int2":        "smallint",
+	"int4":        "integer",
+	"timestamptz": "timestamp",
 }
 
 // PostgreSqlModel gets table information from information_schema、pg_catalog

--- a/tools/goctl/rpc/cli/cli.go
+++ b/tools/goctl/rpc/cli/cli.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 
 	"github.com/tal-tech/go-zero/tools/goctl/rpc/generator"
 	"github.com/tal-tech/go-zero/tools/goctl/util"
+	"github.com/tal-tech/go-zero/tools/goctl/util/env"
 	"github.com/urfave/cli"
 )
 
@@ -14,6 +16,10 @@ import (
 // you can specify a target folder for code generation, when the proto file has import, you can specify
 // the import search directory through the proto_path command, for specific usage, please refer to protoc -h
 func RPC(c *cli.Context) error {
+	if err := prepare(); err != nil {
+		return err
+	}
+
 	src := c.String("src")
 	out := c.String("dir")
 	style := c.String("style")
@@ -39,6 +45,22 @@ func RPC(c *cli.Context) error {
 	}
 
 	return g.Generate(src, out, protoImportPath, goOptions...)
+}
+
+func prepare() error {
+	if !env.CanExec() {
+		return fmt.Errorf("%s: can not start new processes using os.StartProcess or exec.Command", runtime.GOOS)
+	}
+	if _, err := env.LookUpGo(); err != nil {
+		return err
+	}
+	if _, err := env.LookUpProtoc(); err != nil {
+		return err
+	}
+	if _, err := env.LookUpProtocGenGo(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // RPCNew is to generate rpc greet service, this greet service can speed

--- a/tools/goctl/util/env/env.go
+++ b/tools/goctl/util/env/env.go
@@ -1,0 +1,79 @@
+package env
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/tal-tech/go-zero/tools/goctl/vars"
+)
+
+const bin = "bin"
+const binGo = "go"
+const binProtoc = "protoc"
+const binProtocGenGo = "protoc-gen-go"
+
+// LookUpGo searches an executable go in the directories
+// named by the GOROOT/bin or PATH environment variable.
+func LookUpGo() (string, error) {
+	goRoot := runtime.GOROOT()
+	suffix := getExeSuffix()
+	xGo := binGo + suffix
+	path := filepath.Join(goRoot, bin, xGo)
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+	return LookPath(xGo)
+}
+
+// LookUpProtoc searches an executable protoc in the directories
+// named by the PATH environment variable.
+func LookUpProtoc() (string, error) {
+	suffix := getExeSuffix()
+	xProtoc := binProtoc + suffix
+	return LookPath(xProtoc)
+}
+
+// LookUpProtocGenGo searches an executable protoc-gen-go in the directories
+// named by the PATH environment variable.
+func LookUpProtocGenGo() (string, error) {
+	suffix := getExeSuffix()
+	xProtocGenGo := binProtocGenGo + suffix
+	return LookPath(xProtocGenGo)
+}
+
+// LookPath searches for an executable named file in the
+// directories named by the PATH environment variable,
+// for the os windows, the named file will be spliced with the
+// .exe suffix.
+func LookPath(xBin string) (string, error) {
+	suffix := getExeSuffix()
+	if len(suffix) > 0 && strings.HasSuffix(xBin, suffix) {
+		xBin = xBin + suffix
+	}
+
+	bin, err := exec.LookPath(xBin)
+	if err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+// CanExec reports whether the current system can start new processes
+// using os.StartProcess or (more commonly) exec.Command.
+func CanExec() bool {
+	switch runtime.GOOS {
+	case vars.OsJs, vars.OsIOS:
+		return false
+	default:
+		return true
+	}
+}
+func getExeSuffix() string {
+	if runtime.GOOS == vars.OsWindows {
+		return ".exe"
+	}
+	return ""
+}

--- a/tools/goctl/util/env/env.go
+++ b/tools/goctl/util/env/env.go
@@ -50,7 +50,7 @@ func LookUpProtocGenGo() (string, error) {
 // .exe suffix.
 func LookPath(xBin string) (string, error) {
 	suffix := getExeSuffix()
-	if len(suffix) > 0 && strings.HasSuffix(xBin, suffix) {
+	if len(suffix) > 0 && !strings.HasSuffix(xBin, suffix) {
 		xBin = xBin + suffix
 	}
 

--- a/tools/goctl/util/env/env.go
+++ b/tools/goctl/util/env/env.go
@@ -71,6 +71,7 @@ func CanExec() bool {
 		return true
 	}
 }
+
 func getExeSuffix() string {
 	if runtime.GOOS == vars.OsWindows {
 		return ".exe"

--- a/tools/goctl/vars/settings.go
+++ b/tools/goctl/vars/settings.go
@@ -5,10 +5,14 @@ const (
 	ProjectName = "zero"
 	// ProjectOpenSourceURL the github url of go-zero
 	ProjectOpenSourceURL = "github.com/tal-tech/go-zero"
-	// OsWindows windows os
+	// OsWindows represents os windows
 	OsWindows = "windows"
-	// OsMac mac os
+	// OsMac represents os mac
 	OsMac = "darwin"
-	// OsLinux linux os
+	// OsLinux represents os linux
 	OsLinux = "linux"
+	// OsJs represents os js
+	OsJs = "js"
+	// OsIOS represents os ios
+	OsIOS = "ios"
 )


### PR DESCRIPTION
* Optimize `go`, `protoc`, `protoc-gen-go` environment detection
* Check if the current OS supports `exec.Command` or `os.StartProcess` to start processes