### PR TITLE
sharedcalls panic fixed

### DIFF
--- a/core/syncx/sharedcalls_test.go
+++ b/core/syncx/sharedcalls_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -149,31 +148,27 @@ func TestExclusiveCallDoExDupSuppress(t *testing.T) {
 // TestExclusiveCallDoErrPanic: when fn panic, catch it
 func TestExclusiveCallDoErrPanic(t *testing.T) {
 	g := NewSharedCalls()
-
-	c := time.After(5*time.Second)
+	g.SetCatch(true)
+	c := time.After(5 * time.Second)
 	var i int32
 	for {
 		atomic.AddInt32(&i, 1)
 		go func() {
 			v, err := g.Do("key", func() (interface{}, error) {
-				x := rand.Intn(99999)
-				fmt.Println(i, x)
-				if x > 99000 {
-					panic("is panic")
-				}
+				panic("is panic")
 				return 1, nil
 			})
 			if err != nil {
 				t.Errorf("error = %v;", err)
-			}else {
+			} else {
 				t.Log("val is:", v)
 			}
+			t.Log(i, v, err)
 		}()
-		if i > 99999 {
+		if i > 10 {
 			break
 		}
 	}
-
 
 	for {
 		select {

--- a/tools/goctl/util/err/panic.go
+++ b/tools/goctl/util/err/panic.go
@@ -1,0 +1,32 @@
+package err
+
+import (
+	"bytes"
+	"fmt"
+	"runtime/debug"
+)
+
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func NewPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}


### PR DESCRIPTION
当shardcalls遇到panic时会导致崩溃，因此需要捕获异常。

解决方案参照：
https://cs.opensource.google/go/x/sync/+/30421366ff761c80b137fb5084b32278ed41fab0:singleflight/singleflight.go;drc=09787c993a3ab68e3d1f5c9b2394ab9433f391be;bpv=1;l=34

因为我们并不需要支持返回通道的方式，所以简化支持了一下。