### PR TITLE
修复使用 postgres 数据库时，位置参数重复，导致参数与值不对应的问题。

### DIFF
--- a/tools/goctl/model/sql/builderx/builder.go
+++ b/tools/goctl/model/sql/builderx/builder.go
@@ -125,7 +125,7 @@ func RawFieldNames(in interface{}, postgresSql ...bool) []string {
 func PostgreSqlJoin(elems []string) string {
 	b := new(strings.Builder)
 	for index, e := range elems {
-		b.WriteString(fmt.Sprintf("%s = $%d, ", e, index+1))
+		b.WriteString(fmt.Sprintf("%s = $%d, ", e, index+2))
 	}
 
 	if b.Len() == 0 {

--- a/tools/goctl/model/sql/builderx/builder_test.go
+++ b/tools/goctl/model/sql/builderx/builder_test.go
@@ -121,5 +121,5 @@ func TestBuildSqlLike(t *testing.T) {
 
 func TestJoin(t *testing.T) {
 	ret := PostgreSqlJoin([]string{"name", "age"})
-	assert.Equal(t, "name = $1, age = $2", ret)
+	assert.Equal(t, "name = $2, age = $3", ret)
 }

--- a/tools/goctl/model/sql/gen/update.go
+++ b/tools/goctl/model/sql/gen/update.go
@@ -33,7 +33,11 @@ func genUpdate(table Table, withCache, postgreSql bool) (string, string, error) 
 		keyVariableSet.AddStr(key.KeyLeft)
 	}
 
-	expressionValues = append(expressionValues, "data."+table.PrimaryKey.Name.ToCamel())
+	if postgreSql {
+		expressionValues = append([]string{"data." + table.PrimaryKey.Name.ToCamel()}, expressionValues...)
+	} else {
+		expressionValues = append(expressionValues, "data."+table.PrimaryKey.Name.ToCamel())
+	}
 	camelTableName := table.Name.ToCamel()
 	text, err := util.LoadTemplate(category, updateTemplateFile, template.Update)
 	if err != nil {

--- a/zrpc/internal/clientinterceptors/opentracinginterceptor.go
+++ b/zrpc/internal/clientinterceptors/opentracinginterceptor.go
@@ -66,7 +66,7 @@ func StreamOpenTracingInterceptor() grpc.StreamClientInterceptor {
 		requestMetadata, _ := metadata.FromOutgoingContext(ctx)
 		metadataCopy := requestMetadata.Copy()
 
-		tr := otel.Tracer("ecoplants")
+		tr := otel.Tracer(opentelemetry.TraceName)
 
 		name, attr := opentelemetry.SpanInfo(method, cc.Target())
 		var span trace.Span


### PR DESCRIPTION
**修改前**
生成的更新语句
`update t set a=$1,b=$2 where id=$1`
执行参数顺序
`data.a, data.b, data.id`

**修改后**
`update t set a=$2,b=$3 where id=$1`
执行参数顺序
`data.id, data.a, data.b`