### PR TITLE
Fix context error in grpc

### DIFF
--- a/zrpc/err.go
+++ b/zrpc/err.go
@@ -1,6 +1,0 @@
-package zrpc
-
-import "github.com/tal-tech/go-zero/zrpc/internal/codes"
-
-// AddBreakerErrors add customized breaker errors for the client and server.
-var AddBreakerErrors = codes.AddBreakerErrors

--- a/zrpc/err.go
+++ b/zrpc/err.go
@@ -1,0 +1,6 @@
+package zrpc
+
+import "github.com/tal-tech/go-zero/zrpc/internal/codes"
+
+// AddRejectBreakerErrors add customized breaker errors for the client and server.
+var AddRejectBreakerErrors = codes.AddRejectBreakerErrors

--- a/zrpc/err.go
+++ b/zrpc/err.go
@@ -2,5 +2,5 @@ package zrpc
 
 import "github.com/tal-tech/go-zero/zrpc/internal/codes"
 
-// AddRejectBreakerErrors add customized breaker errors for the client and server.
-var AddRejectBreakerErrors = codes.AddRejectBreakerErrors
+// AddBreakerErrors add customized breaker errors for the client and server.
+var AddBreakerErrors = codes.AddBreakerErrors

--- a/zrpc/internal/codes/accept.go
+++ b/zrpc/internal/codes/accept.go
@@ -8,17 +8,17 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// rejectErrors storage rejected errors.
-var rejectErrors = make(map[error]lang.PlaceholderType)
+// breakerErrors storage rejected errors.
+var breakerErrors = make(map[error]lang.PlaceholderType)
 
-// once only allow rejectErrors to be added once.
+// once only allow breakerErrors to be added once.
 var once sync.Once
 
-// AddRejectBreakerErrors add customized breaker errors for the client and server.
-func AddRejectBreakerErrors(errs ...error) {
+// AddBreakerErrors add customized breaker errors for the client and server.
+func AddBreakerErrors(errs ...error) {
 	once.Do(func() {
 		for _, err := range errs {
-			rejectErrors[err] = lang.Placeholder
+			breakerErrors[err] = lang.Placeholder
 		}
 	})
 }
@@ -36,6 +36,6 @@ func Acceptable(err error) bool {
 }
 
 func acceptableUnknown(err error) bool {
-	_, ok := rejectErrors[err]
+	_, ok := breakerErrors[err]
 	return !ok
 }

--- a/zrpc/internal/codes/accept.go
+++ b/zrpc/internal/codes/accept.go
@@ -1,11 +1,27 @@
 package codes
 
 import (
-	"context"
+	"github.com/tal-tech/go-zero/core/lang"
+	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// rejectErrors storage rejected errors.
+var rejectErrors = make(map[error]lang.PlaceholderType)
+
+// once only allow rejectErrors to be added once.
+var once sync.Once
+
+// AddRejectBreakerErrors add customized breaker errors for the client and server.
+func AddRejectBreakerErrors(errs ...error) {
+	once.Do(func() {
+		for _, err := range errs {
+			rejectErrors[err] = lang.Placeholder
+		}
+	})
+}
 
 // Acceptable checks if given error is acceptable.
 func Acceptable(err error) bool {
@@ -20,10 +36,6 @@ func Acceptable(err error) bool {
 }
 
 func acceptableUnknown(err error) bool {
-	switch err {
-	case context.DeadlineExceeded:
-		return false
-	default:
-		return true
-	}
+	_, ok := rejectErrors[err]
+	return !ok
 }

--- a/zrpc/internal/codes/accept.go
+++ b/zrpc/internal/codes/accept.go
@@ -1,41 +1,16 @@
 package codes
 
 import (
-	"github.com/tal-tech/go-zero/core/lang"
-	"sync"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-// breakerErrors storage rejected errors.
-var breakerErrors = make(map[error]lang.PlaceholderType)
-
-// once only allow breakerErrors to be added once.
-var once sync.Once
-
-// AddBreakerErrors add customized breaker errors for the client and server.
-func AddBreakerErrors(errs ...error) {
-	once.Do(func() {
-		for _, err := range errs {
-			breakerErrors[err] = lang.Placeholder
-		}
-	})
-}
 
 // Acceptable checks if given error is acceptable.
 func Acceptable(err error) bool {
 	switch status.Code(err) {
 	case codes.DeadlineExceeded, codes.Internal, codes.Unavailable, codes.DataLoss:
 		return false
-	case codes.Unknown:
-		return acceptableUnknown(err)
 	default:
 		return true
 	}
-}
-
-func acceptableUnknown(err error) bool {
-	_, ok := breakerErrors[err]
-	return !ok
 }

--- a/zrpc/internal/codes/accept_test.go
+++ b/zrpc/internal/codes/accept_test.go
@@ -1,7 +1,6 @@
 package codes
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,8 +9,7 @@ import (
 )
 
 func TestAccept(t *testing.T) {
-	err := errors.New("custom error")
-	AddBreakerErrors(err)
+
 	tests := []struct {
 		name   string
 		err    error
@@ -25,10 +23,6 @@ func TestAccept(t *testing.T) {
 		{
 			name:   "deadline error",
 			err:    status.Error(codes.DeadlineExceeded, "deadline"),
-			accept: false,
-		}, {
-			name:   "custom error",
-			err:    err,
 			accept: false,
 		},
 	}

--- a/zrpc/internal/codes/accept_test.go
+++ b/zrpc/internal/codes/accept_test.go
@@ -1,6 +1,7 @@
 package codes
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,8 @@ import (
 )
 
 func TestAccept(t *testing.T) {
+	err := errors.New("custom error")
+	AddRejectBreakerErrors(err)
 	tests := []struct {
 		name   string
 		err    error
@@ -22,6 +25,10 @@ func TestAccept(t *testing.T) {
 		{
 			name:   "deadline error",
 			err:    status.Error(codes.DeadlineExceeded, "deadline"),
+			accept: false,
+		}, {
+			name:   "custom error",
+			err:    err,
 			accept: false,
 		},
 	}

--- a/zrpc/internal/codes/accept_test.go
+++ b/zrpc/internal/codes/accept_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccept(t *testing.T) {
 	err := errors.New("custom error")
-	AddRejectBreakerErrors(err)
+	AddBreakerErrors(err)
 	tests := []struct {
 		name   string
 		err    error

--- a/zrpc/internal/serverinterceptors/timeoutinterceptor.go
+++ b/zrpc/internal/serverinterceptors/timeoutinterceptor.go
@@ -2,7 +2,6 @@ package serverinterceptors
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -51,9 +50,9 @@ func UnaryTimeoutInterceptor(timeout time.Duration) grpc.UnaryServerInterceptor 
 		case <-ctx.Done():
 			err := ctx.Err()
 
-			if errors.Is(err, context.Canceled) {
+			if err == context.Canceled {
 				err = status.Error(codes.Canceled, err.Error())
-			} else if errors.Is(err, context.DeadlineExceeded) {
+			} else if err == context.DeadlineExceeded {
 				err = status.Error(codes.DeadlineExceeded, err.Error())
 			}
 			return nil, err

--- a/zrpc/internal/serverinterceptors/timeoutinterceptor_test.go
+++ b/zrpc/internal/serverinterceptors/timeoutinterceptor_test.go
@@ -2,6 +2,8 @@ package serverinterceptors
 
 import (
 	"context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"sync"
 	"testing"
 	"time"
@@ -66,5 +68,24 @@ func TestUnaryTimeoutInterceptor_timeoutExpire(t *testing.T) {
 		return nil, nil
 	})
 	wg.Wait()
-	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.EqualValues(t, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error()), err)
+}
+func TestUnaryTimeoutInterceptor_cancel(t *testing.T) {
+	const timeout = time.Minute * 10
+	interceptor := UnaryTimeoutInterceptor(timeout)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/",
+	}, func(ctx context.Context, req interface{}) (interface{}, error) {
+		defer wg.Done()
+		time.Sleep(time.Millisecond * 50)
+		return nil, nil
+	})
+
+	wg.Wait()
+	assert.EqualValues(t, status.Error(codes.Canceled, context.Canceled.Error()), err)
 }


### PR DESCRIPTION
目的:

将context返回的错误,转换成grpc可以识别的错误

该PR合并后,以下代码将永远不会被执行,应该移除它
https://github.com/tal-tech/go-zero/blob/d0f9e5702289b32b5d289ad2418d8b91b0807c6e/zrpc/internal/codes/accept.go#L24-L25