### PR TITLE
检查锁是否失效给锁续期

### DIFF
--- a/core/stores/redis/redislock.go
+++ b/core/stores/redis/redislock.go
@@ -73,6 +73,17 @@ func (rl *RedisLock) Acquire() (bool, error) {
 	return false, nil
 }
 
+func (rl *RedisLock) AcquireLockWithTimeout() (bool, error) {
+	end := time.Now().Add(time.Duration(rl.seconds))
+	for time.Now().Before(end) {
+		ttl, err := rl.store.Ttl(rl.key)
+		if ttl == -1 && err == nil {
+			return rl.Acquire()
+		}
+	}
+	return true, nil
+}
+
 // Release releases the lock.
 func (rl *RedisLock) Release() (bool, error) {
 	resp, err := rl.store.Eval(delCommand, []string{rl.key}, []string{rl.id})


### PR DESCRIPTION
如题:https://go-zero.dev/cn/redis-lock.html 这是文档中的关于redis lock的文档,其中
```redisLock.SetExpire(redisLockExpireSeconds) 设置了过期时间,
```

假如是5毫秒,业务执行需要4毫秒,这时候是没问题的，假如业务有时候需要10毫秒,这时候key已经失效了,需要对其key进行续期